### PR TITLE
Change repository links in Dockerfile and readme

### DIFF
--- a/.devcontainer/Dockerfile.dev
+++ b/.devcontainer/Dockerfile.dev
@@ -52,7 +52,7 @@ RUN curl -L -o exist-distribution-${EXIST_VERSION}-unix.tar.bz2 https://github.c
     && rm exist-distribution-${EXIST_VERSION}-unix.tar.bz2 \
     && mv /usr/local/exist-distribution-${EXIST_VERSION} /usr/local/exist
 
-RUN  git clone --depth 1 -b main https://github.com/bullinger-digital/bullinger-korpus-tei.git
+RUN  git clone --depth 1 -b main https://github.com/stazh/bullinger-korpus-tei.git
 
 RUN cd /workspaces/bullinger-korpus-tei \
     && ant \

--- a/Dockerfile
+++ b/Dockerfile
@@ -38,11 +38,11 @@ ARG TEMPLATING_VERSION=1.1.0
 ARG PUBLISHER_LIB_VERSION=4.0.0
 ARG ROUTER_VERSION=1.8.1
 
-RUN  git clone --depth 1 -b main https://github.com/bullinger-digital/bullinger-app.git \
+RUN  git clone --depth 1 -b main https://github.com/stazh/bullinger-app.git \
     && cd bullinger-app \
     && ant
 
-RUN  git clone --depth 1 -b main https://github.com/bullinger-digital/bullinger-korpus-tei.git \
+RUN  git clone --depth 1 -b main https://github.com/stazh/bullinger-korpus-tei.git \
     && cd bullinger-korpus-tei \
     && ant
 

--- a/README.md
+++ b/README.md
@@ -5,4 +5,4 @@
 **Bullinger Digital** is developed using [TEI Publisher](https://teipublisher.com/index.html), a specialized framework for publishing digital editions.
 
 For more information about the project, please see the separate data repository at 
-[https://github.com/bullinger-digital/bullinger-korpus-tei](https://github.com/bullinger-digital/bullinger-korpus-tei).
+[https://github.com/stazh/bullinger-korpus-tei](https://github.com/stazh/bullinger-korpus-tei).


### PR DESCRIPTION
The Dockerfiles in this repository still point to the repositories of the [bullinger-digital](https://github.com/bullinger-digital) GitHub organisation. This PR updates the links to the [stazh](https://github.com/stazh/) organisation.