### PR TITLE
CSS change: add z-index to dropdown-menu and overflow to footer

### DIFF
--- a/resources/css/bullinger-theme.css
+++ b/resources/css/bullinger-theme.css
@@ -176,6 +176,10 @@ footer {
     text-align: center;
 }
 
+footer {
+    overflow: hidden;
+}
+
 footer,
 footer a,
 footer a:link,
@@ -370,6 +374,7 @@ a.btn-search-reset:hover {
     display:block;
     opacity: 1;
     transform: scaleY(1);
+    z-index: 1500;
 }
 .dropdown-menu > li ul li {
     display: block;


### PR DESCRIPTION
Fixes styling issues of the dropdown menu and the footer:

1. On the Localities page, the menu overlay was rendered behind the Leaflet map controls when opened. This was resolved by setting a high z-index value.

<img width="258" alt="image" src="https://github.com/user-attachments/assets/654cde38-d941-4ac0-94a0-6bd246f8214f" />

2. The footer, which has a white background, did not fully cover the bottom margin of its inner p tag. As a result, an area with the page's grey background color was visible beneath the footer. This was fixed by setting the overflow property to 'auto'. (The issue is also visible on the Localities page.)

<img width="655" alt="image" src="https://github.com/user-attachments/assets/8a32e35d-8918-46f7-86bd-932024319449" />
