### PR TITLE
Sticky control section for name and language highlighting in letters

### DIFF
--- a/modules/ext-common.xql
+++ b/modules/ext-common.xql
@@ -27,7 +27,7 @@ declare function ext:get-header($letter, $lang-browser as xs:string?) {
                 <a title="Nächster Brief (mit gleichen Korrespondenten)" href="./{$next-letter-correspondence}"><iron-icon icon="chevron-right"/><iron-icon class="double-icon" icon="chevron-right"/></a>
                 <a title="Nächster Brief (nach Datum)" href="./{$next-letter}"><iron-icon icon="chevron-right"/></a>
                 <span class="letter-navigation-mark-names">
-                    <label><input type="checkbox" onclick="javascript:document.body.classList.toggle('colorize-named-entities', this.checked)" /> <pb-i18n key="mark-named-entities">(Namen markieren)</pb-i18n></label>
+                    <label><input type="checkbox" id="entityCheckbox" onclick="this.dispatchEvent(new CustomEvent('toggle-entities', &#123;bubbles: true, composed: true, detail: &#123; checked&#58; this.checked &#125;&#125;))" /> <pb-i18n key="mark-named-entities">(Namen markieren)</pb-i18n></label>
                 </span>
             </div>
         </div>

--- a/resources/css/bullinger-theme.css
+++ b/resources/css/bullinger-theme.css
@@ -121,7 +121,7 @@ body {
 body.colorize-named-entities {
     --bb-named-entity-person-color: hsla(48,97%,77%,.7);
     --bb-named-entity-place-color: rgba(167,243,208,.7);
-    --bb-named-entity-padding: 0.10rem 0.3rem;
+    --bb-named-entity-padding: 0.05rem 0;
     --bb-named-entity-border-radius: 0.25rem;
 }
 
@@ -1150,6 +1150,23 @@ pb-split-list::part(items) {
     border-bottom: 1px solid #f5f5f5;
     padding: 1.4rem 2rem 1.2rem 2rem;
     margin-bottom: 0;
+}
+
+.section-letter-text-controls {
+    background: var(--tify-header-bg,#f5f5f5);
+    box-shadow: 0 1px var(--tify-border-color,rgba(0,0,0,.2));
+    box-sizing: border-box;
+    min-height: 3.375rem;
+    padding: 0.4rem 1.8rem;
+    position: sticky;
+    top: 0;
+    z-index: 10000;
+}
+
+.section-letter-text-controls__list {
+    list-style: none;
+    margin: 0;
+    padding: 0;
 }
 
 .section-content { 

--- a/resources/odd/bullinger.css
+++ b/resources/odd/bullinger.css
@@ -196,6 +196,10 @@ display: block;
     margin: auto var(--s-2);
 }
 
+.lang-usage {
+    margin-bottom: 1rem;
+}
+
 /* enforce whitespace between lanaguage name and percentage */
 .lang-usage-percent::before {
     content: ' ';

--- a/templates/pages/letter.html
+++ b/templates/pages/letter.html
@@ -42,8 +42,19 @@
                         </div>
                     </div>
                     <div class="transkription card">
-                        <h2 class="section-title"><pb-i18n key="letterText">(Brieftext)</pb-i18n> <span data-template="app:transcription-source"></span> 
-                          <small class="small-t"><label for="lang-toggle"><input type="checkbox" name="lang-toggle" id="lang-toggle" value="test" />&#160;<pb-i18n key="showLanguage">(Show Language)</pb-i18n></label></small></h2>
+                        <h2 class="section-title"><pb-i18n key="letterText">(Brieftext)</pb-i18n> <span data-template="app:transcription-source"></span></h2>
+                        <div class="section-letter-text-controls">
+                            <ul class="section-letter-text-controls__list">
+                                <li>
+                                    <span class="letter-navigation-mark-names">
+                                        <label><input type="checkbox" class="js-toggle-entities" onclick="this.dispatchEvent(new CustomEvent('toggle-entities', {bubbles: true, detail: { checked: this.checked }}))" />&#160;<pb-i18n key="mark-named-entities">(Namen markieren)</pb-i18n></label>
+                                    </span>
+                                </li>
+                                <li>
+                                    <label for="lang-toggle"><input type="checkbox" name="lang-toggle" id="lang-toggle" value="test" />&#160;<pb-i18n key="showLanguage">(Show Language)</pb-i18n></label>
+                                </li>
+                            </ul>
+                        </div>
                         <div class="section-content">
                             <pb-view id="view1" src="document1" column-separator=".tei-cb" append-footnotes="append-footnotes" subscribe="transcription" emit="transcription" use-language="" view="single" />
                             <pb-view id="facsimile-links" src="document1" xpath="//facsimile" view="single" wait-for="#facsimile" emit="facsimile" use-language="">


### PR DESCRIPTION
**Usability improvement**:
Adds a sticky section to the letter template containing checkboxes for highlighting named entities and language fragments. The section remains visible while scrolling, ensuring that users can easily toggle text highlighting at any time.
Previously, only a single checkbox for named entity highlighting was placed below the header. This checkbox was easy to miss and would disappear when scrolling. Now, an additional checkbox is placed directly above the letter text. The state of both checkboxes is synchronized using custom events.

<img width="1165" alt="image" src="https://github.com/user-attachments/assets/84045c28-6ea3-4dcc-9d96-021803193f98" />

<img width="1160" alt="image" src="https://github.com/user-attachments/assets/63f6826b-bd50-447e-b288-535528fe28bd" />

<img width="474" alt="image" src="https://github.com/user-attachments/assets/4b4359d5-65d6-4953-85c1-923b9cac782a" />
