### PR TITLE
Add link wrapper and title attribute to portrait image

### DIFF
--- a/modules/ext-common.xql
+++ b/modules/ext-common.xql
@@ -60,9 +60,12 @@ declare function ext:get-header($letter, $lang-browser as xs:string?) {
                             {
                                 for $p in $persons
                                 let $url := $p//tei:idno[@subtype='portrait']/text()
+                                let $id := $p/@xml:id/string()
                                 let $title := $p/tei:persName[@type='main']//tei:forename || " " || $p/tei:persName[@type='main']//tei:surname
                                 return <div class="portrait">
-                                    <img src="resources/portraits/{$url}" alt="{$title}" />
+                                    <a class="portrait__link" href="./persons/{$id}">
+                                        <img class="portrait__image" src="resources/portraits/{$url}" alt="{$title}" title="{$title}" />
+                                    </a>
                                 </div>
                             }
                         </div>

--- a/resources/css/bullinger-shadow.css
+++ b/resources/css/bullinger-shadow.css
@@ -78,3 +78,12 @@
 .portrait-container:hover .portrait {
     margin-left:-1rem;
 }
+
+.portrait__link {
+    display: inline-block;
+    line-height: 0;
+}
+
+.portrait__image {
+  display: block;
+}


### PR DESCRIPTION
**Usability improvement**:
Portrait images on letter detail pages are now clickable and lead to the respective person detail pages.
To enhance accessibility and orientation, a title attribute shows the person's name as a tooltip when hovering over the image.

<img width="176" alt="image" src="https://github.com/user-attachments/assets/9b6de44a-5ebb-4518-87b3-de582f0683f6" />
