### PR TITLE
Add correspondence filter and usage tooltips to localities view

### DIFF
--- a/modules/custom-api.json
+++ b/modules/custom-api.json
@@ -700,6 +700,14 @@
                         "schema":{
                             "type": "string"
                         }
+                    },
+                    {
+                        "name": "view",
+                        "in": "query",
+                        "schema": {
+                            "type": "string",
+                            "default": ""
+                        }
                     }
                 ],
                 "responses": {

--- a/modules/custom-api.xql
+++ b/modules/custom-api.xql
@@ -20,6 +20,7 @@ import module namespace roaster="http://e-editiones.org/roaster";
 
 import module namespace ext="http://teipublisher.com/ext-common" at "ext.xql";
 import module namespace pm-config="http://www.tei-c.org/tei-simple/pm-config" at "pm-config.xql";
+import module namespace mapping = "http://www.bullinger-digital.ch/mapping" at "mapping.xqm";
 
 declare variable $api:QUERY_OPTIONS := map {
     "leading-wildcard": "yes",
@@ -114,27 +115,53 @@ declare function api:persons-all-list-sort($entries as element()*, $sortBy as xs
             reverse($sorted)
 };
 
+(:~
+ : API function for listing localities, grouped by initial letter and filtered by correspondence/mention count.
+ : Accepts request parameters like "search", "category", "dir", "limit", "view".
+ :)
 declare function api:localities-all-list($request as map(*)) {
     let $search := normalize-space($request?parameters?search)
     let $letterParam := $request?parameters?category    
     let $sortDir := $request?parameters?dir
-    let $limit := $request?parameters?limit      
-    
-    let $places :=     
-            if ($search and $search != '') 
-            then (
-                $config:localities//tei:place[ft:query(., '(name:(' || $search || '*) OR mentioned-names:(' || $search || '*))', map {
-                    "leading-wildcard": "yes",
-                    "filter-rewrite": "yes"
-                })]
-            ) 
-            else (
-                $config:localities//tei:place[ft:query(., 'name:*', map {
-                    "leading-wildcard": "yes",
-                    "filter-rewrite": "yes"
-                })]
-            )            
-    
+    let $limit := $request?parameters?limit
+    let $view := $request?parameters?view
+    let $options := api:get-register-query-options()
+
+    (: --- Get localities mapping --- :)
+    let $mapping := mapping:get-localities()
+
+    (: --- Construct Lucene query based on view mode and search term --- :)
+    let $baseQuery :=
+        if ($view = "correspondence") then "name:*"
+        else "name:* OR mentioned-names:*"
+
+    let $query :=
+        if ($search != "") then
+            if ($view = "correspondence") then
+                "name:(" || $search || "*)"
+            else
+                "name:(" || $search || "*) OR mentioned-names:(" || $search || "*)"
+        else
+            $baseQuery 
+
+    (: --- Perform fulltext search on localities --- :)
+    let $rawPlaces := $config:localities//tei:place[
+        ft:query(., $query, $options)
+    ]
+
+    (: --- Filter localities based on usage mapping --- :)
+    let $places := 
+        for $place in $rawPlaces
+        let $id := $place/@xml:id/string()
+        let $placeCounts := $mapping($id)
+        where exists($placeCounts)
+        and (
+            ($view = "correspondence" and $placeCounts?corresp > 0) or
+            ($view != "correspondence" and ($placeCounts?corresp + $placeCounts?mentions) > 0)
+        )
+        return $place
+
+    (: --- Group results by first uppercase letter of name field --- :)
     let $byLetter :=
         map:merge(
             for $place in $places
@@ -144,6 +171,8 @@ declare function api:localities-all-list($request as map(*)) {
             return
                 map:entry($letter, $place)
         )
+
+    (: --- Determine selected letter category --- :)
     let $letter :=
         if ((count($places) < $limit) or $search != '') then
             "[A-Z]"
@@ -152,11 +181,14 @@ declare function api:localities-all-list($request as map(*)) {
         else
             $letterParam
 
+    (: --- Select items to return based on selected letter category --- :)
     let $itemsToShow :=
         if ($letter = '[A-Z]') then
             $places
         else
             $byLetter($letter)
+
+    (: --- Build and return the final response map --- :)
     return
         map {
             "items": api:output-locality($itemsToShow, $letter, $search),
@@ -183,43 +215,62 @@ declare function api:localities-all-list($request as map(*)) {
 };
 
 declare function api:output-locality($list, $letter as xs:string, $search as xs:string?) {
-    array {
-        for $place in $list
-            let $name := ft:field($place, 'name')[1]
-            return
-                if(string-length($name)>0)
-                then (                       
-                let $categoryParam := if ($letter = "[A-Z]") then substring($name, 1, 1) else $letter
-                let $params := "&amp;category=" || $categoryParam || "&amp;search=" || $search                           
-                let $coords := tokenize($place/tei:location/tei:geo)
-                return
-                    element span {
-                        attribute class { "place" },
-                        element span {
-                            element a {
-                                attribute href { $place/@xml:id || "?" || $params },
-                                $name
-                            }
-                        },
-                        if(string-length(normalize-space($place/tei:location/tei:geo)) > 0)
-                        then (
-                            element pb-geolocation {
-                                attribute latitude { $coords[1] },
-                                attribute longitude { $coords[2] },
-                                attribute label { $name},
-                                attribute emit {"map"},
-                                attribute event { "click" },
-                                attribute zoom { 9 },
+    let $count := count($list)
+    return
+        array {
+            element p {
+                attribute class { "result-count" },
+                <pb-i18n key="registers.resultsCount.localities">Gefundene Orte</pb-i18n>,
+                text { ":" },
+                element span {
+                    attribute class { "result-count-output" },
+                    $count
+                }
+            },
+            element ul {
+                attribute class { "place-list" },
+                for $place in $list
+                    let $name := ft:field($place, 'name')[1]
+                    return
+                        if(string-length($name)>0)
+                        then (                       
+                        let $categoryParam := if ($letter = "[A-Z]") then substring($name, 1, 1) else $letter
+                        let $params := "&amp;category=" || $categoryParam || "&amp;search=" || $search                           
+                        let $coords := tokenize($place/tei:location/tei:geo)
+                        return
+                            element li {
+                                attribute class { "place-item" },
+                                element a {
+                                    attribute class { "place-link" },
+                                    attribute href { $place/@xml:id || "?" || $params },
+                                    element span {
+                                        attribute class { "place-name" },
+                                        $name
+                                    },
+                                    if(string-length(normalize-space($place/tei:location/tei:geo)) > 0)
+                                    then (
+                                        element pb-geolocation {
+                                            attribute class { "place-geolocation" },
+                                            attribute latitude { $coords[1] },
+                                            attribute longitude { $coords[2] },
+                                            attribute label { $name},
+                                            attribute emit { "map" },
+                                            attribute event { "click" },
+                                            attribute zoom { 9 },
 
-                                element iron-icon {
-                                    attribute icon {"maps:map" }
+                                            element iron-icon {
+                                                attribute class { "place-icon" },
+                                                attribute icon { "maps:place" },
+                                                attribute fill { "currentColor" }
+                                            }
+                                        }
+                                    )
+                                    else ()
                                 }
                             }
-                        )
-                        else ()
-                    }
-                ) else()
-    }
+                        ) else()
+            }
+        }
 };
 
 declare function api:localities-all($request as map(*)) {    

--- a/modules/custom-api.xql
+++ b/modules/custom-api.xql
@@ -191,7 +191,7 @@ declare function api:localities-all-list($request as map(*)) {
     (: --- Build and return the final response map --- :)
     return
         map {
-            "items": api:output-locality($itemsToShow, $letter, $search),
+            "items": api:output-locality($itemsToShow, $letter, $search, $mapping),
             "categories":
                 if ((count($places) < $limit)  or $search != '') then
                     []
@@ -214,7 +214,7 @@ declare function api:localities-all-list($request as map(*)) {
         }
 };
 
-declare function api:output-locality($list, $letter as xs:string, $search as xs:string?) {
+declare function api:output-locality($list, $letter as xs:string, $search as xs:string?, $mapping as map(*)) {
     let $count := count($list)
     return
         array {
@@ -231,6 +231,10 @@ declare function api:output-locality($list, $letter as xs:string, $search as xs:
                 attribute class { "place-list" },
                 for $place in $list
                     let $name := ft:field($place, 'name')[1]
+                    let $id := $place/@xml:id/string()
+                    let $placeCounts := $mapping($id)
+                    let $corresp := if (exists($placeCounts?corresp)) then $placeCounts?corresp else 0
+                    let $mentions := if (exists($placeCounts?mentions)) then $placeCounts?mentions else 0
                     return
                         if(string-length($name)>0)
                         then (                       
@@ -246,6 +250,32 @@ declare function api:output-locality($list, $letter as xs:string, $search as xs:
                                     element span {
                                         attribute class { "place-name" },
                                         $name
+                                    },
+                                    element span {
+                                        attribute class { "place-counts-tooltip" },
+                                        element span {
+                                            attribute class { "place-counts-label" },
+                                            element pb-i18n {
+                                                attribute key { "registers.correspondenceAndMentions" }
+                                            }
+                                        },
+                                        text { ": " },
+                                        element span {
+                                            attribute class { "place-counts-value" },
+                                            ($corresp + $mentions)
+                                        },
+                                        element br {},
+                                        element span {
+                                            attribute class { "place-counts-label" },
+                                            element pb-i18n {
+                                                attribute key { "registers.correspondence" }
+                                            }
+                                        },
+                                        text { ": " },
+                                        element span {
+                                            attribute class { "place-counts-value" },
+                                            $corresp
+                                        }
                                     },
                                     if(string-length(normalize-space($place/tei:location/tei:geo)) > 0)
                                     then (

--- a/modules/mapping.xqm
+++ b/modules/mapping.xqm
@@ -1,0 +1,45 @@
+xquery version "3.1";
+
+module namespace mapping = "http://www.bullinger-digital.ch/mapping";
+
+(:~
+ : Module to load and cache locality mapping data from CSV file.
+ : The CSV file is read once on first load, and results are stored
+ : in a static variable for fast reuse.
+ :)
+
+(: Path to the CSV file :)
+declare variable $mapping:csv-path := '/db/apps/bullinger-data/data/mapping/localities-mapping.csv';
+
+(:~
+ : Cached locality data, loaded once at module load time.
+ :)
+declare variable $mapping:localities := mapping:init-localities();
+
+(:~
+ : Initialize locality data from CSV file. This runs once per module load.
+ : The CSV file contains 3 columns: placeID, corresp and mentions.
+ :)
+declare function mapping:init-localities() as map(*) {
+    let $lines := tokenize(util:binary-to-string(util:binary-doc($mapping:csv-path)), '\r?\n')
+    
+    return map:merge(
+        for $line in subsequence($lines, 2) (: skip header :)
+        let $cols := tokenize($line, ',')
+        where count($cols) = 3
+        let $placeID := $cols[1]
+        let $corresp := xs:integer($cols[2])
+        let $mentions := xs:integer($cols[3])
+        return map:entry($placeID, map {
+            "corresp": $corresp,
+            "mentions": $mentions
+        })
+    )
+};
+
+(:~
+ : Return cached mapping.
+ :)
+declare function mapping:get-localities() as map(*) {
+    $mapping:localities
+};

--- a/resources/css/bullinger-theme.css
+++ b/resources/css/bullinger-theme.css
@@ -45,6 +45,7 @@
     --bb-field-gray: rgb(233,237,234);
     --bb-field-gray-500: rgb(83, 101, 88);
     --bb-beige: rgba(170,129,90);
+    --bb-beige-dark: #8a6e4e;
     --bb-footer-color: var(--bb-white);
     --bb-lang-de-color: rgb(220, 249, 222);
     --bb-lang-el-color: rgb(250, 229, 235);
@@ -144,7 +145,7 @@ body.colorize-named-entities {
     display: inline-block;
 }
 .bullinger-button:hover {
-    background-color: #8a6e4e;
+    background-color: var(--bb-beige-dark);
 }
 
 .center-l {
@@ -417,9 +418,13 @@ main {
     --pb-browse-toolbar-justify-content: space-between;
 }
 
-a, a:link, a:visited, a:hover, a:active {
+a, a:link, a:visited, a:active {
     text-decoration: none;
     color: var(--bb-beige);
+}
+
+a:hover {
+    color: var(--bb-beige-dark);
 }
 
 main .panels .doclist {
@@ -528,6 +533,28 @@ pb-collapse > div{
 }
 .facets pb-combo-box {
     margin-bottom: 0.2rem;
+}
+
+pb-custom-form.facets .radios {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 1rem;
+}
+
+pb-custom-form.facets .radio-option {
+    align-items: center;
+    cursor: pointer;
+    display: flex;
+    font-size: 16px;
+    gap: 0.5rem;  
+}
+
+pb-custom-form.facets .radio-option:hover {
+    color: var(--bb-beige-dark);
+}
+
+pb-custom-form.facets .radio-input {
+    margin: 0;
 }
 
 @media (max-width: 1023px) {
@@ -854,9 +881,36 @@ pb-view {
     float:left;
 }
 
+.place-list {
+    list-style: none;
+    padding: 0;
+    margin: 0 0 0 -0.2rem;
+}
+
+.place-list .place-link {
+    display: inline-block;
+}
+
+.place-list .place-name {
+    padding-right: 1rem;
+}
+
+.place-list iron-icon.place-icon {
+    --iron-icon-fill-color: var(--bb-beige);
+    margin-right: 0.3rem;
+}
+
+.place-list .place-item:hover a.place-link {
+    color: var(--bb-beige-dark);
+}
+
+.place-list .place-item:hover iron-icon.place-icon {
+    --iron-icon-fill-color: var(--bb-beige-dark);        
+}
+
 .register-list pb-custom-form {
     justify-self: start;
-    max-width: 30rem;
+    max-width: 35rem;
     width: 100%;
     margin-bottom: 1rem;
 }
@@ -865,16 +919,48 @@ pb-view {
     display: grid;
     grid-template-columns: 1fr 1fr;
     grid-gap: var(--s3);
+    margin-top: 3rem;
+    grid-template-areas: "first second";
+}
+
+@media (max-width: 768px) {
+    .register__localities {
+        grid-gap: var(--s1);
+        grid-template-columns: 1fr;
+        grid-template-areas:
+        "second"
+        "first";
+        margin-top: 1rem;
+    }
 }
 
 .register__localities .register-list {
     --pb-categorized-list-columns: 1;
+    grid-area: first;
+}
+
+.register__localities .result-count {
+    margin: 0 0 1rem;
+}
+
+.register__localities .result-count-output {
+    padding: 0 0.7rem;
+}
+
+.register__localities .register-list pb-custom-form.facets {
+    margin-bottom: 0;
 }
 
 .register__localities pb-leaflet-map {
-    margin-top: 5rem;
+    grid-area: second;
     width: 100%;
     height: 50vh;
+}
+
+@media (max-width: 768px) {
+    .register__localities pb-leaflet-map {
+        height: 30vh;
+    }
 }
 
 .bio-footnotes-more {
@@ -913,6 +999,13 @@ pb-view {
     margin: var(--s0) 0;
     max-width: 100%;
     height: 32rem;
+}
+
+@media (max-width: 768px) {
+    .detail-locality pb-leaflet-map#map {
+        height: 30vh;
+        width: 100%;
+    }
 }
 
 .detail-image {
@@ -980,12 +1073,24 @@ pb-split-list::part(active-category) {
     background: green;
 } */
 
+
+pb-split-list::part(category),
+pb-split-list::part(active-category) {
+    border-radius: 0.3rem;
+    box-sizing: border-box;
+    margin-bottom: 0.2rem;
+    min-width: 1.1rem;
+    padding: 0 0.1rem;
+    text-align: center;
+}
+
 pb-split-list::part(category) {
     color: var(--bb-dark-gray);
 }
 
 pb-split-list::part(active-category) {
-    color: var(--bb-black);
+    color: var(--bb-white);
+    background-color: var(--bb-beige-dark);
 }
 
 pb-split-list::part(items) {

--- a/resources/css/bullinger-theme.css
+++ b/resources/css/bullinger-theme.css
@@ -889,10 +889,35 @@ pb-view {
 
 .place-list .place-link {
     display: inline-block;
+    position: relative;
 }
 
 .place-list .place-name {
     padding-right: 1rem;
+}
+
+.place-list .place-counts-tooltip {
+    background: var(--bb-white);
+    border: 1px solid var(--bb-light-gray);
+    border-radius: 0.5rem;
+    color: var(--bb-dark-gray);
+    display: none;
+    font-size: 0.9rem;
+    padding: 0.5rem 1rem;
+    position: absolute;
+    top: 0;
+    white-space: nowrap;
+    z-index: 500;
+}
+
+.place-list .place-counts-label,
+.place-list .place-counts-value {
+    display: inline-block;
+    white-space: nowrap;
+}
+
+.place-list .place-counts-value {
+    font-weight: bold;
 }
 
 .place-list iron-icon.place-icon {
@@ -906,6 +931,10 @@ pb-view {
 
 .place-list .place-item:hover iron-icon.place-icon {
     --iron-icon-fill-color: var(--bb-beige-dark);        
+}
+
+.place-list .place-item:hover .place-counts-tooltip {
+    display: inline-block;
 }
 
 .register-list pb-custom-form {

--- a/resources/i18n/app/de.json
+++ b/resources/i18n/app/de.json
@@ -169,6 +169,9 @@
             "date": "Datum",
             "recipients": "Empfänger",
             "recipients-place": "Empfangsort"
+        },
+        "resultsCount": {
+            "localities": "Gefundene Orte"
         }
     },
     "sent": "Gesendet",

--- a/resources/i18n/app/en.json
+++ b/resources/i18n/app/en.json
@@ -169,6 +169,9 @@
             "date": "Date",
             "recipients": "Recipient",
             "recipients-place": "Place of Receipt"
+        },
+        "resultsCount": {
+            "localities": "Found Places"
         }
     },
     "sent": "Sent",

--- a/templates/localities.html
+++ b/templates/localities.html
@@ -12,12 +12,30 @@
             </header>
             <main class="register register__localities center-l">
                 <div class="register-list">
+                    <pb-custom-form id="filter" class="facets" auto-submit="[name=view]" emit="transcription">
+                        <div class="radios">
+                            <label class="radio-option">
+                                <input class="radio-input" type="radio" name="view" checked="checked" value="all" data-template="templates:form-control" />
+                                <pb-i18n key="registers.correspondenceAndMentions">Korrespondenz und Erwähnungen</pb-i18n>
+                            </label>
+                            <label class="radio-option">
+                                <input class="radio-input" type="radio" name="view" value="correspondence" data-template="templates:form-control" />
+                                <pb-i18n key="registers.correspondence">Korrespondenz</pb-i18n>
+                            </label>
+                        </div>
+                    </pb-custom-form>
                     <pb-custom-form id="options" auto-submit="paper-input,paper-icon-button" emit="transcription">
                         <paper-input id="query" name="search" data-i18n="[label]registers.search" label="(Search)" data-template="templates:form-control">
                             <paper-icon-button icon="search" slot="suffix"/>
                         </paper-input>
                     </pb-custom-form>
-                    <pb-split-list class="register-split-list" url="api/localities-all-list" subforms="#options" selected="A" emit="transcription" subscribe="transcription" data-template="pages:parse-params"/>
+                    <pb-split-list class="register-split-list" 
+                        url="api/localities-all-list" 
+                        subforms="#options,#filter" 
+                        selected="A" 
+                        emit="transcription" 
+                        subscribe="transcription" 
+                        data-template="pages:parse-params"/>
                 </div>
                 <pb-leaflet-map id="map" subscribe="map" emit="map" zoom="10" cluster="" latitude="47.3686498" longitude="8.5391825">
                     <pb-map-layer show=""


### PR DESCRIPTION
Enables filtering of localities based on actual usage in the letters. Depending on the selected view mode, either all places (correspondence and mentions) or only those directly involved in correspondence are displayed.

Locality usage data (correspondence + mentions) is read from a CSV file generated by the Bullinger corpus repo. The corresponding PR is: https://github.com/stazh/bullinger-korpus-tei/pull/2

Each place in the localities list now displays a tooltip on hover, showing the total number of correspondence and mentions, as well as the number of correspondence entries.