### PR TITLE
Change letter navigation markup and styling

### DIFF
--- a/modules/ext-common.xql
+++ b/modules/ext-common.xql
@@ -19,15 +19,36 @@ declare function ext:get-header($letter, $lang-browser as xs:string?) {
     let $next-letter-correspondence := $navigation-item/tei:ptr[@type='next-same-correspondents']/@target
     let $type := $letter/ancestor::tei:TEI/@type/string()
 
-    return <div>
+    return <div class="top-container">
         <div class="letter-navigation">
-            <div class="center-l">
-                <a title="Vorheriger Brief (nach Datum)" href="./{$previous-letter}"><iron-icon icon="chevron-left"/></a>
-                <a title="Vorheriger Brief (mit gleichen Korrespondenten)" href="./{$previous-letter-correspondence}"><iron-icon icon="chevron-left"/><iron-icon class="double-icon" icon="chevron-left"/></a>
-                <a title="Nächster Brief (mit gleichen Korrespondenten)" href="./{$next-letter-correspondence}"><iron-icon icon="chevron-right"/><iron-icon class="double-icon" icon="chevron-right"/></a>
-                <a title="Nächster Brief (nach Datum)" href="./{$next-letter}"><iron-icon icon="chevron-right"/></a>
+            <div class="letter-navigation-inner center-l">
+                <span class="letter-navigation-group">
+                    <iron-icon class="letter-navigation-group-icon" icon="date-range" aria-hidden="true" fill="currentColor"/>
+                    <a class="letter-navigation-link" href="./{$previous-letter}">
+                        <iron-icon class="letter-navigation-icon" icon="chevron-left"/>
+                        <span class="letter-navigation-tooltip"><pb-i18n key="navigation.previous-letter-by-date">Vorheriger Brief nach Datum</pb-i18n></span>
+                    </a>
+                    <a class="letter-navigation-link" href="./{$next-letter}">
+                        <iron-icon class="letter-navigation-icon" icon="chevron-right"/>
+                        <span class="letter-navigation-tooltip"><pb-i18n key="navigation.next-letter-by-date">Nächster Brief nach Datum</pb-i18n></span>
+                    </a>
+                </span>
+                <span class="letter-navigation-group">
+                    <iron-icon class="letter-navigation-group-icon" icon="social:people" aria-hidden="true" fill="currentColor"/>
+                    <a class="letter-navigation-link" href="./{$previous-letter-correspondence}">
+                        <iron-icon class="letter-navigation-icon" icon="chevron-left"/>
+                        <span class="letter-navigation-tooltip"><pb-i18n key="navigation.previous-letter-by-correspondents">Vorheriger Brief mit gleichen Korrespondenten</pb-i18n></span>
+                    </a>
+                    <a class="letter-navigation-link" href="./{$next-letter-correspondence}">
+                        <iron-icon class="letter-navigation-icon" icon="chevron-right"/>
+                        <span class="letter-navigation-tooltip"><pb-i18n key="navigation.next-letter-by-correspondents">Nächster Brief mit gleichen Korrespondenten</pb-i18n></span>
+                    </a>
+                </span>
                 <span class="letter-navigation-mark-names">
-                    <label><input type="checkbox" onclick="javascript:document.body.classList.toggle('colorize-named-entities', this.checked)" /> <pb-i18n key="mark-named-entities">(Namen markieren)</pb-i18n></label>
+                    <label>
+                        <input type="checkbox" onclick="javascript:document.body.classList.toggle('colorize-named-entities', this.checked)" />
+                        <pb-i18n key="mark-named-entities">(Namen markieren)</pb-i18n>
+                    </label>
                 </span>
             </div>
         </div>

--- a/resources/css/bullinger-theme.css
+++ b/resources/css/bullinger-theme.css
@@ -40,11 +40,13 @@
     --bb-page-bg-color: rgb(249, 250, 251);
     --bb-pale: #f0f0f0;
     --bb-light-gray: #ddd;
+    --bb-gray: #BDBDBD;
     --bb-dark-gray: #777;
     --bb-black: #303030;
     --bb-field-gray: rgb(233,237,234);
     --bb-field-gray-500: rgb(83, 101, 88);
     --bb-beige: rgba(170,129,90);
+    --bb-beige-dark: #8a6e4e;
     --bb-footer-color: var(--bb-white);
     --bb-lang-de-color: rgb(220, 249, 222);
     --bb-lang-el-color: rgb(250, 229, 235);
@@ -53,6 +55,9 @@
     --bb-lang-fr-color: rgb(229 220 247);
     --bb-lang-it-color: rgb(229 160 247);
     --bb-lang-en-color: rgb(229 250 120);
+    --bb-link: var(--bb-beige);
+    --bb-link-hover: var(--bb-beige-dark);
+    --bb-link-disabled: var(--bb-gray);
 
 
     --pb-link-color: var(--bb-black);

--- a/resources/i18n/app/de.json
+++ b/resources/i18n/app/de.json
@@ -190,5 +190,11 @@
         "after": "nach",
         "before": "vor",
         "unknown": "unbekannt"
+    },
+    "navigation": {
+        "previous-letter-by-date": "Vorheriger Brief nach Datum",
+        "next-letter-by-date": "Nächster Brief nach Datum",
+        "previous-letter-by-correspondents": "Vorheriger Brief mit gleichen Korrespondenten",
+        "next-letter-by-correspondents": "Nächster Brief mit gleichen Korrespondenten"
     }
 }

--- a/resources/i18n/app/en.json
+++ b/resources/i18n/app/en.json
@@ -190,5 +190,11 @@
         "after": "after",
         "before": "before",
         "unknown": "unknown"
+    },
+    "navigation": {
+        "previous-letter-by-date": "Previous letter by date",
+        "next-letter-by-date": "Next letter by date",
+        "previous-letter-by-correspondents": "Previous letter between same correspondents",
+        "next-letter-by-correspondents": "Next letter between same correspondents"
     }
 }

--- a/resources/odd/bullinger.css
+++ b/resources/odd/bullinger.css
@@ -237,25 +237,79 @@ a[rel=footnote] {
     color: var(--pb-footnote-color)
 }
 
-.letter-navigation a[href='./'] {
-    color: #BDBDBD;
-    pointer-events: none;
-}
-
 .letter-navigation {
     background: var(--bb-pale);
 }
-.letter-navigation iron-icon.double-icon {
-    margin-left: -18px;
-}
-.letter-navigation > div {
-    padding: 5px 0;
-    display: flex;
+
+.letter-navigation-inner {
     align-items: center;
+    display: flex;
+    gap: 0.7rem;
+    padding: 0.35rem 1rem;
+}
+
+.letter-navigation-group {
+    align-items: center;
+    display: flex;
+    gap: 0.5rem;
+    padding-right: 0.5rem;
+    position: relative;
+}
+
+.letter-navigation-group::after {
+    background-color: var(--bb-gray);
+    content: '';
+    height: 1.3rem;
+    position: absolute;
+    right: 0;
+    top: 50%;
+    transform: translateY(-50%);
+    width: 1px;
+}
+
+.letter-navigation-group-icon {
+    --iron-icon-fill-color: var(--bb-field-gray-500);
+}
+
+.letter-navigation-link {
+    align-items: center;
+    color: var(--bb-link);
+    display: inline-flex;
+    gap: 0.1rem;
+    position: relative;
+}
+
+.letter-navigation-link:hover {
+    color: var(--bb-link-hover);
+}
+
+.letter-navigation-link[href='./'],
+.letter-navigation-link[href='./']:hover {
+    color: var(--bb-link-disabled);
+    pointer-events: none;
+}
+
+.letter-navigation-tooltip {
+    background: var(--bb-white);
+    border: 1px solid var(--bb-light-gray);
+    border-radius: 0.5rem;
+    box-shadow: 0 0 10px rgba(0,0,0,0.1);
+    color: var(--bb-link);
+    display: none;
+    font-size: 0.9rem;
+    padding: 0.5rem 1rem;
+    position: absolute;
+    left: 0;
+    top: 1.5rem;
+    white-space: nowrap;
+    z-index: 500;
+}
+
+.letter-navigation-link:hover .letter-navigation-tooltip {
+    display: inline-block;
 }
 
 .letter-navigation-mark-names {
-    margin-left: 15px;
     margin-top: -2px;
     font-family: var(--bb-font-family-sans);
 }
@@ -264,9 +318,11 @@ a[rel=footnote] {
     display: flex;
     align-items:center;
 }
+
 .letter-navigation-mark-names input {
     margin-right: 5px;
 }
+
 .header-container {
     display:flex;
     justify-content:space-between;


### PR DESCRIPTION
**Usability improvement**:

This pull request enhances the usability and accessibility of the letter navigation component on the letter detail page.

- Replaced double-chevron icons previously used for navigating between the same correspondents, as users might misinterpret them as “go to first/last” actions.
- Added clear semantic labels using <pb-i18n> to support multilingual contexts:
	•	Previous letter by date
	•	Next letter by date
	•	Previous letter between same correspondents
	•	Next letter between same correspondents
- Implemented custom tooltips via CSS, which become visible on hover, improving clarity and accessibility compared to purely attribute-based descriptions.
- Used CSS pseudo-elements (::after) to visually separate navigation groups clearly, ensuring better readability.
- Each navigation group now features a distinct and meaningful icon: calendar icon for date-based navigation, people icon for navigation between the same correspondents.

<img width="637" alt="image" src="https://github.com/user-attachments/assets/37c6b357-7838-427c-adcd-1da600f8f8a3" />
