### PR TITLE
Fix timeline clipping issue and overflow in mobile view

### DIFF
--- a/resources/css/bullinger-theme.css
+++ b/resources/css/bullinger-theme.css
@@ -1160,3 +1160,12 @@ pb-split-list::part(items) {
     display: block!important;
     white-space:nowrap;
 }
+
+.timeline {
+    width: 100%;
+    overflow-x: scroll;
+}
+
+.timeline pb-timeline {
+    width: 96%
+}


### PR DESCRIPTION
This PR improves the horizontal scrolling behavior of the timeline component:

- The timeline container (which wraps the pb-timeline component) now has overflow-x: scroll and takes full width. Before on mobile, users had to scroll the entire page horizontally to view the full timeline. Now only the timeline container scrolls horizontally.

<img width="468" alt="image" src="https://github.com/user-attachments/assets/833bd84d-acd7-4ad5-aa09-e63dfa1f0331" />
<img width="461" alt="image" src="https://github.com/user-attachments/assets/f4fe9426-d47d-44f5-93cf-c7c5a0633343" />



- The inner pb-timeline element is slightly reduced in width (96%) to prevent clipping of the final label ("1580 – 1589") on the right edge. Now all timeline labels are fully visible.

<img width="1170" alt="image" src="https://github.com/user-attachments/assets/afca5830-5214-4487-8a02-b00714447582" />
