### PR TITLE
Fix incorrect years on index page

### DIFF
--- a/static/home-de.html
+++ b/static/home-de.html
@@ -6,7 +6,7 @@
                 <h1 class="home-main-heading">Willkommen bei Bullinger Digital</h1>
                 <p class="home-intro-text">
                     Mit Bullinger Digital erhalten Sie Zugriff auf den digital erschlossenen Briefwechsel von Heinrich
-                    Bullinger (1505-1574).
+                    Bullinger (1504-1575).
                 </p>
                 <a class="bullinger-button" href="letters.html">Online-Suchsystem</a>
             </div>

--- a/static/home-en.html
+++ b/static/home-en.html
@@ -6,7 +6,7 @@
                 <h1 class="home-main-heading">Welcome to<br />Bullinger Digital</h1>
                 <p class="home-intro-text">
                     Bullinger Digital gives you access to the digitally edited correspondence of Heinrich Bullinger
-                    (1505-1574).
+                    (1504-1575).
                 </p>
                 <a class="bullinger-button" href="letters.html">Online Search System</a>
             </div>


### PR DESCRIPTION
Unfortunately, Bullinger’s birth and death years on the index page were incorrect because two digits were swapped. This PR corrects them.