### PR TITLE
Enhance localities register with improved map integration, statistics and filters

### DIFF
--- a/modules/custom-api.json
+++ b/modules/custom-api.json
@@ -724,26 +724,6 @@
                 }
             }
         },
-        "/api/localities-all": {
-            "get": {
-                "summary": "List all places",
-                "description": "Retrieve list of all places",
-                "operationId": "custom:localities-all",
-                "parameters": [],
-				"responses": {
-                    "200": {
-                        "description": "List of all places",
-                        "content": {
-                            "application/json": {
-                                "schema":{
-                                    "type": "array"
-                                }
-                            }
-                        }
-                    }
-				}
-			}
-		},
 		"/api/locality/{key}": {
             "get": {
                 "summary": "List register entries",

--- a/modules/custom-api.json
+++ b/modules/custom-api.json
@@ -668,7 +668,7 @@
         "/api/localities-all-list": {
             "get": {
                 "summary": "List localities",
-                "description": "Retrieve list of pllocalitiesaces in format required by pb-split-list",
+                "description": "Retrieve list of places/localities in format required by pb-split-list",
                 "operationId": "custom:localities-all-list",
                 "parameters": [
 					{
@@ -678,14 +678,6 @@
 							"type": "string"
 						}
 					},					
-                    {
-                        "name": "dir",
-                        "in": "query",
-                        "schema": {
-                            "type": "string",
-                            "default": "asc"
-                        }
-                    },					
                     {
                         "name": "limit",
                         "in": "query",
@@ -706,9 +698,23 @@
                         "in": "query",
                         "schema": {
                             "type": "string",
-                            "default": ""
+                            "default": "all"
                         }
-                    }
+                    },
+                    {
+  						"name": "correspSent",
+  						"in": "query",
+  						"schema": {
+    						"type": "string"
+  						}
+					},
+					{
+						"name": "correspReceived",
+						"in": "query",
+						"schema": {
+							"type": "string"
+						}
+					}
                 ],
                 "responses": {
                     "200": {

--- a/modules/custom-api.json
+++ b/modules/custom-api.json
@@ -698,7 +698,8 @@
                         "in": "query",
                         "schema": {
                             "type": "string",
-                            "default": "all"
+                            "default": "all",
+                            "enum": ["all", "correspondence", "mentions"]
                         }
                     },
                     {
@@ -806,7 +807,8 @@
                         "in": "query",
                         "schema": {
                             "type": "string",
-                            "default": ""
+                            "default": "all",
+                            "enum": ["all", "correspondence", "mentions"]
                         }
                     },
 					{

--- a/modules/custom-api.xql
+++ b/modules/custom-api.xql
@@ -128,15 +128,17 @@ declare function api:localities-all-list($request as map(*)) {
         else
             50
     let $view :=
-        if (normalize-space($request?parameters?view) = "correspondence") then
-            "correspondence"
-        else
-            "all"
-    let $sentSelected := $request?parameters?correspSent = "1"
-    let $receivedSelected := $request?parameters?correspReceived = "1"
+        let $value := normalize-space($request?parameters?view)
+        return
+            if ($value = ("correspondence", "mentions")) then
+                $value
+            else
+                "all"
+    let $correspSentSelected := $request?parameters?correspSent = "1"
+    let $correspReceivedSelected := $request?parameters?correspReceived = "1"
 
     let $allCorrespPlaces := 
-        ($sentSelected and $receivedSelected) or not($sentSelected or $receivedSelected)
+        ($correspSentSelected and $correspReceivedSelected) or not($correspSentSelected or $correspReceivedSelected)
 
     let $options := api:get-register-query-options()
 
@@ -145,13 +147,19 @@ declare function api:localities-all-list($request as map(*)) {
 
     (: --- Construct Lucene query based on view mode and search term --- :)
     let $baseQuery :=
-        if ($view = "correspondence") then "name:*"
-        else "name:* OR mentioned-names:*"
+        if ($view = "correspondence") then 
+            "name:*"
+        else if ($view = "mentions") then 
+            "mentioned-names:*"
+        else 
+            "name:* OR mentioned-names:*"
 
     let $query :=
         if ($search != "") then
             if ($view = "correspondence") then
                 "name:(" || $search || "*)"
+            else if ($view = "mentions") then
+                "mentioned-names:(" || $search || "*)"
             else
                 "name:(" || $search || "*) OR mentioned-names:(" || $search || "*)"
         else
@@ -172,12 +180,14 @@ declare function api:localities-all-list($request as map(*)) {
             if ($view = "correspondence") then
                 if ($allCorrespPlaces) then
                     $placeCounts?corresp > 0
-                else if ($sentSelected) then
-                    $placeCounts?sent > 0
+                else if ($correspSentSelected) then
+                    $placeCounts?correspSent > 0
                 else
-                    $placeCounts?received > 0
-            else
+                    $placeCounts?correspReceived > 0
+            else if ($view = "mentions") then
                 $placeCounts?mentions > 0
+            else
+                $placeCounts?correspAndMentions > 0
         )
         return $place
 
@@ -317,8 +327,9 @@ declare function api:output-locality($list, $letter as xs:string, $search as xs:
                 let $id := $place/@xml:id/string()
                 let $placeCounts := $mapping($id)
                 let $corresp := if (exists($placeCounts?corresp)) then $placeCounts?corresp else 0
-                let $sent := if (exists($placeCounts?sent)) then $placeCounts?sent else 0
-                let $received := if (exists($placeCounts?received)) then $placeCounts?received else 0
+                let $correspSent := if (exists($placeCounts?correspSent)) then $placeCounts?correspSent else 0
+                let $correspReceived := if (exists($placeCounts?correspReceived)) then $placeCounts?correspReceived else 0
+                let $correspAndMentions := if (exists($placeCounts?correspAndMentions)) then $placeCounts?correspAndMentions else 0
                 let $mentions := if (exists($placeCounts?mentions)) then $placeCounts?mentions else 0
                 let $geo := normalize-space($place/tei:location/tei:geo)
                 let $coords := tokenize($geo)
@@ -384,7 +395,7 @@ declare function api:output-locality($list, $letter as xs:string, $search as xs:
                                         text { ": " },
                                         element span {
                                             attribute class { "place-counts-value" },
-                                            $mentions
+                                            $correspAndMentions
                                         },
                                         element br {},
                                         element span {
@@ -416,7 +427,7 @@ declare function api:output-locality($list, $letter as xs:string, $search as xs:
                                                 text { ": " },
                                                 element span {
                                                     attribute class { "place-counts-value" },
-                                                    $sent
+                                                    $correspSent
                                                 }
                                             },
                                             element br {},
@@ -435,10 +446,23 @@ declare function api:output-locality($list, $letter as xs:string, $search as xs:
                                                 text { ": " },
                                                 element span {
                                                     attribute class { "place-counts-value" },
-                                                    $received
+                                                    $correspReceived
                                                 }
                                             }
-                                        ) else ()
+                                        ) else (),
+
+                                        element br {},
+                                        element span {
+                                            attribute class { "place-counts-label" },
+                                            element pb-i18n {
+                                                attribute key { "registers.mentions" }
+                                            }
+                                        },
+                                        text { ": " },
+                                        element span {
+                                            attribute class { "place-counts-value" },
+                                            $mentions
+                                        }
                                     }
                                 }
                             }
@@ -791,6 +815,15 @@ declare function api:locality-filter($filter as xs:string?, $key as xs:string, $
     let $letters := switch ($view)
         case "correspondence" return
             $all-letters[ft:query(.//tei:text, 'place:' || $key , $options)]
+        case "mentions" return
+            $all-letters[
+                ft:query(.//tei:text, 'mentioned-places:' || $key, $options)
+            ][
+                .//tei:placeName[
+                    @ref = $key
+                    and not(ancestor::tei:correspAction)
+                ]
+            ]
         default return
             $all-letters[ft:query(.//tei:text, 'place:' || $key || ' OR mentioned-places:' || $key , $options)]
     let $result := 

--- a/modules/custom-api.xql
+++ b/modules/custom-api.xql
@@ -235,22 +235,59 @@ declare function api:output-locality($list, $letter as xs:string, $search as xs:
                     let $placeCounts := $mapping($id)
                     let $corresp := if (exists($placeCounts?corresp)) then $placeCounts?corresp else 0
                     let $mentions := if (exists($placeCounts?mentions)) then $placeCounts?mentions else 0
+                    let $geo := normalize-space($place/tei:location/tei:geo)
+                    let $coords := tokenize($geo)
                     return
                         if(string-length($name)>0)
                         then (                       
                         let $categoryParam := if ($letter = "[A-Z]") then substring($name, 1, 1) else $letter
-                        let $params := "&amp;category=" || $categoryParam || "&amp;search=" || $search                           
-                        let $coords := tokenize($place/tei:location/tei:geo)
+                        let $params := "&amp;category=" || $categoryParam || "&amp;search=" || $search
                         return
                             element li {
-                                attribute class { "place-item" },
-                                element a {
-                                    attribute class { "place-link" },
-                                    attribute href { $place/@xml:id || "?" || $params },
+                                attribute class { "js-place-item place-item" },
+                            
+                                if (count($coords) = 2) then
+                                    element pb-geolocation {
+                                        attribute class { "place-geolocation" },
+                                        attribute latitude { $coords[1] },
+                                        attribute longitude { $coords[2] },
+                                        attribute label { $name },
+                                        attribute data-place-id { $id },
+                                        attribute emit { "map" },
+                                        attribute event { "click" },
+                                        attribute zoom { 12 },
+                            
+                                        element iron-icon {
+                                            attribute class { "place-icon" },
+                                            attribute icon { "maps:place" },
+                                            attribute fill { "currentColor" }
+                                        }
+                                    }
+                                else (
                                     element span {
-                                        attribute class { "place-name" },
-                                        $name
+                                        attribute class { "place-geolocation place-geolocation--disabled" },
+                                
+                                        element iron-icon {
+                                            attribute class { "no-geolocation-icon" },
+                                            attribute icon { "social:public" },
+                                            attribute fill { "currentColor" }
+                                        }
+                                    }
+                                ),
+                            
+                                element div {
+                                    attribute class { "place-main" },
+                            
+                                    element a {
+                                        attribute class { "js-place-link place-link" },
+                                        attribute href { $place/@xml:id || "?" || $params },
+                            
+                                        element span {
+                                            attribute class { "place-name" },
+                                            $name
+                                        }
                                     },
+                            
                                     element span {
                                         attribute class { "place-counts-tooltip" },
                                         element span {
@@ -276,57 +313,13 @@ declare function api:output-locality($list, $letter as xs:string, $search as xs:
                                             attribute class { "place-counts-value" },
                                             $corresp
                                         }
-                                    },
-                                    if(string-length(normalize-space($place/tei:location/tei:geo)) > 0)
-                                    then (
-                                        element pb-geolocation {
-                                            attribute class { "place-geolocation" },
-                                            attribute latitude { $coords[1] },
-                                            attribute longitude { $coords[2] },
-                                            attribute label { $name},
-                                            attribute emit { "map" },
-                                            attribute event { "click" },
-                                            attribute zoom { 9 },
-
-                                            element iron-icon {
-                                                attribute class { "place-icon" },
-                                                attribute icon { "maps:place" },
-                                                attribute fill { "currentColor" }
-                                            }
-                                        }
-                                    )
-                                    else ()
+                                    }
                                 }
                             }
                         ) else()
             }
         }
 };
-
-declare function api:localities-all($request as map(*)) {    
-    let $places := $config:localities//tei:place[ft:query(., 'name:*', map {
-                    "leading-wildcard": "yes",
-                    "filter-rewrite": "yes"
-                })]
-    return
-        array {
-            for $place in $places
-            return
-                if(string-length(normalize-space($place/tei:location/tei:geo)) > 0)
-                then (
-                    let $tokenized := tokenize($place/tei:location/tei:geo)                    
-                    let $name := ft:field($place, 'name')[1]
-                    return
-                        map {
-                            "latitude":$tokenized[1],
-                            "longitude":$tokenized[2],
-                            "label":$name,
-                            "id":$place/@xml:id/string()
-                        }
-                ) else ()
-            }
-};
-
 
 declare function api:sort-letters($entries as element()*, $sortBy as xs:string, $dir as xs:string) {
     let $sorted :=

--- a/modules/custom-api.xql
+++ b/modules/custom-api.xql
@@ -214,8 +214,70 @@ declare function api:localities-all-list($request as map(*)) {
         }
 };
 
+(:~
+ : Return the i18n key for the locality type represented by the given place.
+ : The type is derived from the available TEI child elements, preferring
+ : settlement over district and district over country.
+ :)
+declare function local:locality-type-key($place as element(tei:place)) as xs:string? {
+    if ($place/tei:settlement) then
+        "registers.localityType.settlement"
+    else if ($place/tei:district) then
+        "registers.localityType.district"
+    else if ($place/tei:country) then
+        "registers.localityType.country"
+    else
+        ()
+};
+
+(:~
+ : Determine whether the locality name should be disambiguated with a type label.
+ : A label is added for duplicate names and for broader geographic entities
+ : such as districts or countries which do not also define a settlement.
+ :)
+declare function local:locality-needs-type-label(
+    $place as element(tei:place),
+    $name as xs:string?,
+    $duplicateNames as xs:string*
+) as xs:boolean {
+    ($name = $duplicateNames)
+    or (exists($place/tei:district) and not($place/tei:settlement))
+    or (exists($place/tei:country) and not($place/tei:settlement) and not($place/tei:district))
+};
+
+(:~
+ : Build the display name for a locality in the localities register.
+ : If needed, an i18n-enabled place type label is appended in square brackets
+ : to distinguish places, regions, and countries.
+ :)
+declare function local:locality-display-name(
+    $place as element(tei:place),
+    $duplicateNames as xs:string*
+) as node()* {
+    let $name := ft:field($place, 'name')[1]
+    let $typeKey := local:locality-type-key($place)
+    return
+        if (local:locality-needs-type-label($place, $name, $duplicateNames) and exists($typeKey)) then (
+            text { $name || " " },
+            text { "[" },
+            element span {
+                attribute class { "place-type" },
+                element pb-i18n { attribute key { $typeKey } }
+            },
+            text { "]" }
+        )
+        else
+            text { $name }
+};
+
 declare function api:output-locality($list, $letter as xs:string, $search as xs:string?, $mapping as map(*)) {
     let $count := count($list)
+    let $duplicateNames :=
+        for $place in $list
+        let $name := ft:field($place, 'name')[1]
+        group by $name
+        where count($place) > 1
+        return $name
     return
         array {
             element p {
@@ -230,22 +292,23 @@ declare function api:output-locality($list, $letter as xs:string, $search as xs:
             element ul {
                 attribute class { "place-list" },
                 for $place in $list
-                    let $name := ft:field($place, 'name')[1]
-                    let $id := $place/@xml:id/string()
-                    let $placeCounts := $mapping($id)
-                    let $corresp := if (exists($placeCounts?corresp)) then $placeCounts?corresp else 0
-                    let $mentions := if (exists($placeCounts?mentions)) then $placeCounts?mentions else 0
-                    let $geo := normalize-space($place/tei:location/tei:geo)
-                    let $coords := tokenize($geo)
-                    return
-                        if(string-length($name)>0)
-                        then (                       
+                let $name := ft:field($place, 'name')[1]
+                let $displayName := local:locality-display-name($place, $duplicateNames)
+                let $id := $place/@xml:id/string()
+                let $placeCounts := $mapping($id)
+                let $corresp := if (exists($placeCounts?corresp)) then $placeCounts?corresp else 0
+                let $mentions := if (exists($placeCounts?mentions)) then $placeCounts?mentions else 0
+                let $geo := normalize-space($place/tei:location/tei:geo)
+                let $coords := tokenize($geo)
+                order by lower-case($name) collation "http://www.w3.org/2013/collation/UCA?lang=de"
+                return
+                    if (string-length($name) > 0) then (
                         let $categoryParam := if ($letter = "[A-Z]") then substring($name, 1, 1) else $letter
                         let $params := "&amp;category=" || $categoryParam || "&amp;search=" || $search
                         return
                             element li {
                                 attribute class { "js-place-item place-item" },
-                            
+
                                 if (count($coords) = 2) then
                                     element pb-geolocation {
                                         attribute class { "place-geolocation" },
@@ -256,7 +319,7 @@ declare function api:output-locality($list, $letter as xs:string, $search as xs:
                                         attribute emit { "map" },
                                         attribute event { "click" },
                                         attribute zoom { 12 },
-                            
+
                                         element iron-icon {
                                             attribute class { "place-icon" },
                                             attribute icon { "maps:place" },
@@ -266,7 +329,7 @@ declare function api:output-locality($list, $letter as xs:string, $search as xs:
                                 else (
                                     element span {
                                         attribute class { "place-geolocation place-geolocation--disabled" },
-                                
+
                                         element iron-icon {
                                             attribute class { "no-geolocation-icon" },
                                             attribute icon { "social:public" },
@@ -274,20 +337,20 @@ declare function api:output-locality($list, $letter as xs:string, $search as xs:
                                         }
                                     }
                                 ),
-                            
+
                                 element div {
                                     attribute class { "place-main" },
-                            
+
                                     element a {
                                         attribute class { "js-place-link place-link" },
-                                        attribute href { $place/@xml:id || "?" || $params },
-                            
+                                        attribute href { $id || "?" || $params },
+
                                         element span {
                                             attribute class { "place-name" },
-                                            $name
+                                            $displayName
                                         }
                                     },
-                            
+
                                     element span {
                                         attribute class { "place-counts-tooltip" },
                                         element span {
@@ -316,7 +379,7 @@ declare function api:output-locality($list, $letter as xs:string, $search as xs:
                                     }
                                 }
                             }
-                        ) else()
+                    ) else ()
             }
         }
 };

--- a/modules/custom-api.xql
+++ b/modules/custom-api.xql
@@ -28,6 +28,12 @@ declare variable $api:QUERY_OPTIONS := map {
 };
 
 (:~
+ : Controls whether locality type labels (e.g. settlement, district, country)
+ : are appended to locality names in the localities register.
+ :)
+declare variable $api:REGISTER_LOCALITIES_SHOW_TYPE_LABELS := false();
+
+(:~
  : Keep this. This function does the actual lookup in the imported modules.
  :)
 declare function api:lookup($name as xs:string, $arity as xs:integer) {
@@ -285,17 +291,21 @@ declare function local:locality-display-name(
     $duplicateNames as xs:string*
 ) as node()* {
     let $name := ft:field($place, 'name')[1]
-    let $typeKey := local:locality-type-key($place)
     return
-        if (local:locality-needs-type-label($place, $name, $duplicateNames) and exists($typeKey)) then (
-            text { $name || " " },
-            text { "[" },
-            element span {
-                attribute class { "place-type" },
-                element pb-i18n { attribute key { $typeKey } }
-            },
-            text { "]" }
-        )
+        if ($api:REGISTER_LOCALITIES_SHOW_TYPE_LABELS) then
+            let $typeKey := local:locality-type-key($place)
+            return
+                if (local:locality-needs-type-label($place, $name, $duplicateNames) and exists($typeKey)) then (
+                    text { $name || " " },
+                    text { "[" },
+                    element span {
+                        attribute class { "place-type" },
+                        element pb-i18n { attribute key { $typeKey } }
+                    },
+                    text { "]" }
+                )
+                else
+                    text { $name }
         else
             text { $name }
 };
@@ -303,11 +313,13 @@ declare function local:locality-display-name(
 declare function api:output-locality($list, $letter as xs:string, $search as xs:string?, $mapping as map(*)) {
     let $count := count($list)
     let $duplicateNames :=
-        for $place in $list
-        let $name := ft:field($place, 'name')[1]
-        group by $name
-        where count($place) > 1
-        return $name
+        if ($api:REGISTER_LOCALITIES_SHOW_TYPE_LABELS) then
+            for $place in $list
+            let $name := ft:field($place, 'name')[1]
+            group by $name
+            where count($place) > 1
+            return $name
+        else ()
     return
         array {
             element p {

--- a/modules/custom-api.xql
+++ b/modules/custom-api.xql
@@ -117,14 +117,27 @@ declare function api:persons-all-list-sort($entries as element()*, $sortBy as xs
 
 (:~
  : API function for listing localities, grouped by initial letter and filtered by correspondence/mention count.
- : Accepts request parameters like "search", "category", "dir", "limit", "view".
+ : Accepts request parameters like "search", "category", "limit", "view", "correspSent", "correspReceived".
  :)
 declare function api:localities-all-list($request as map(*)) {
     let $search := normalize-space($request?parameters?search)
-    let $letterParam := $request?parameters?category    
-    let $sortDir := $request?parameters?dir
-    let $limit := $request?parameters?limit
-    let $view := $request?parameters?view
+    let $letterParam := $request?parameters?category
+    let $limit :=
+        if ($request?parameters?limit castable as xs:integer) then
+            xs:integer($request?parameters?limit)
+        else
+            50
+    let $view :=
+        if (normalize-space($request?parameters?view) = "correspondence") then
+            "correspondence"
+        else
+            "all"
+    let $sentSelected := $request?parameters?correspSent = "1"
+    let $receivedSelected := $request?parameters?correspReceived = "1"
+
+    let $allCorrespPlaces := 
+        ($sentSelected and $receivedSelected) or not($sentSelected or $receivedSelected)
+
     let $options := api:get-register-query-options()
 
     (: --- Get localities mapping --- :)
@@ -149,15 +162,22 @@ declare function api:localities-all-list($request as map(*)) {
         ft:query(., $query, $options)
     ]
 
-    (: --- Filter localities based on usage mapping --- :)
+    (: --- Filter localities based on selected register view and correspondence role --- :)
     let $places := 
         for $place in $rawPlaces
         let $id := $place/@xml:id/string()
         let $placeCounts := $mapping($id)
         where exists($placeCounts)
         and (
-            ($view = "correspondence" and $placeCounts?corresp > 0) or
-            ($view != "correspondence" and $placeCounts?mentions > 0)
+            if ($view = "correspondence") then
+                if ($allCorrespPlaces) then
+                    $placeCounts?corresp > 0
+                else if ($sentSelected) then
+                    $placeCounts?sent > 0
+                else
+                    $placeCounts?received > 0
+            else
+                $placeCounts?mentions > 0
         )
         return $place
 
@@ -166,8 +186,8 @@ declare function api:localities-all-list($request as map(*)) {
         map:merge(
             for $place in $places
             let $name := ft:field($place, 'name')[1]
-            order by $name
-            group by $letter := substring($name, 1, 1) => upper-case()
+            order by lower-case($name)
+            group by $letter := upper-case(substring($name, 1, 1))
             return
                 map:entry($letter, $place)
         )
@@ -297,6 +317,8 @@ declare function api:output-locality($list, $letter as xs:string, $search as xs:
                 let $id := $place/@xml:id/string()
                 let $placeCounts := $mapping($id)
                 let $corresp := if (exists($placeCounts?corresp)) then $placeCounts?corresp else 0
+                let $sent := if (exists($placeCounts?sent)) then $placeCounts?sent else 0
+                let $received := if (exists($placeCounts?received)) then $placeCounts?received else 0
                 let $mentions := if (exists($placeCounts?mentions)) then $placeCounts?mentions else 0
                 let $geo := normalize-space($place/tei:location/tei:geo)
                 let $coords := tokenize($geo)
@@ -375,7 +397,48 @@ declare function api:output-locality($list, $letter as xs:string, $search as xs:
                                         element span {
                                             attribute class { "place-counts-value" },
                                             $corresp
-                                        }
+                                        },
+
+                                        if ($corresp > 0) then (
+                                            element br {},
+                                            element span {
+                                                attribute class { "place-counts-subitem" },
+                                                element span {
+                                                    attribute class { "place-counts-bullet" },
+                                                    text { "•" }
+                                                },
+                                                element span {
+                                                    attribute class { "place-counts-label" },
+                                                    element pb-i18n {
+                                                        attribute key { "registers.correspondencePlaceOfDispatch" }
+                                                    }
+                                                },
+                                                text { ": " },
+                                                element span {
+                                                    attribute class { "place-counts-value" },
+                                                    $sent
+                                                }
+                                            },
+                                            element br {},
+                                            element span {
+                                                attribute class { "place-counts-subitem" },
+                                                element span {
+                                                    attribute class { "place-counts-bullet" },
+                                                    text { "•" }
+                                                },
+                                                element span {
+                                                    attribute class { "place-counts-label" },
+                                                    element pb-i18n {
+                                                        attribute key { "registers.correspondencePlaceOfReceipt" }
+                                                    }
+                                                },
+                                                text { ": " },
+                                                element span {
+                                                    attribute class { "place-counts-value" },
+                                                    $received
+                                                }
+                                            }
+                                        ) else ()
                                     }
                                 }
                             }

--- a/modules/mapping.xqm
+++ b/modules/mapping.xqm
@@ -29,13 +29,15 @@ declare function mapping:init-localities() as map(*) {
         let $placeID := $item/@xml:id/string()
         where exists($placeID)
         let $corresp := xs:integer(($item/*[@type = 'corresp']/string(), "0")[1])
-        let $sent := xs:integer(($item/*[@type = 'sent']/string(), "0")[1])
-        let $received := xs:integer(($item/*[@type = 'received']/string(), "0")[1])
+        let $correspSent := xs:integer(($item/*[@type = 'correspSent']/string(), "0")[1])
+        let $correspReceived := xs:integer(($item/*[@type = 'correspReceived']/string(), "0")[1])
+        let $correspAndMentions := xs:integer(($item/*[@type = 'correspAndMentions']/string(), "0")[1])
         let $mentions := xs:integer(($item/*[@type = 'mentions']/string(), "0")[1])
         return map:entry($placeID, map {
             "corresp": $corresp,
-            "sent": $sent,
-            "received": $received,
+            "correspSent": $correspSent,
+            "correspReceived": $correspReceived,
+            "correspAndMentions": $correspAndMentions,
             "mentions": $mentions
         })
     )

--- a/modules/mapping.xqm
+++ b/modules/mapping.xqm
@@ -28,10 +28,14 @@ declare function mapping:init-localities() as map(*) {
         for $item in $items
         let $placeID := $item/@xml:id/string()
         where exists($placeID)
-        let $corresp := xs:integer($item/*[@type = 'corresp']/string())
-        let $mentions := xs:integer($item/*[@type = 'mentions']/string())
+        let $corresp := xs:integer(($item/*[@type = 'corresp']/string(), "0")[1])
+        let $sent := xs:integer(($item/*[@type = 'sent']/string(), "0")[1])
+        let $received := xs:integer(($item/*[@type = 'received']/string(), "0")[1])
+        let $mentions := xs:integer(($item/*[@type = 'mentions']/string(), "0")[1])
         return map:entry($placeID, map {
             "corresp": $corresp,
+            "sent": $sent,
+            "received": $received,
             "mentions": $mentions
         })
     )

--- a/resources/css/bullinger-theme.css
+++ b/resources/css/bullinger-theme.css
@@ -994,6 +994,45 @@ pb-view {
     min-height: 0;
 }
 
+.register__localities .register-results {
+    position: relative;
+    min-height: 0;
+    height: 100%;
+}
+
+.register__localities .register-loading {
+    align-items: center;
+    background: rgba(255, 255, 255, 0.75);
+    bottom: 0;
+    display: none;
+    justify-content: center;
+    left: 0;
+    position: absolute;
+    right: 0;
+    top: 0;
+    z-index: 20;
+}
+
+.register__localities .register-list.is-loading .register-loading {
+    display: flex;
+}
+
+.register__localities .register-loading iron-icon {
+    --iron-icon-height: 32px;
+    --iron-icon-width: 32px;
+    animation: locality-loading-spin 1s linear infinite;
+    color: var(--bb-beige-dark);
+}
+
+@keyframes locality-loading-spin {
+    from {
+        transform: rotate(0deg);
+    }
+    to {
+        transform: rotate(360deg);
+    }
+}
+
 .register__localities .register-list {
     --pb-categorized-list-columns: 1;
     display: grid;
@@ -1048,7 +1087,7 @@ pb-view {
     display: block;
     min-height: 0;
     overflow-y: auto;
-    padding-bottom: 3rem;
+    padding-bottom: 5rem;
     box-sizing: border-box;
 }
 

--- a/resources/css/bullinger-theme.css
+++ b/resources/css/bullinger-theme.css
@@ -941,6 +941,15 @@ pb-view {
     font-weight: bold;
 }
 
+.place-list .place-counts-subitem {
+    display: inline-block;
+}
+
+.place-list .place-counts-bullet {
+    display: inline-block;
+    width: 0.8rem;
+}
+
 .place-list .place-geolocation {
     display: inline-block;
     flex-shrink: 0;
@@ -1059,6 +1068,48 @@ pb-view {
 
 .register__localities .register-list pb-custom-form.facets {
     margin-bottom: 0;
+}
+
+.register__localities .register-list pb-custom-form.facets .radios--main {
+    display: flex;
+    align-items: flex-start;
+    gap: 1rem;
+    flex-wrap: wrap;
+}
+
+.register__localities .register-list pb-custom-form.facets .radio-option-group {
+    display: flex;
+    flex-direction: column;
+}
+
+.register__localities .register-list pb-custom-form.facets .radio-option,
+.register__localities .register-list pb-custom-form.facets .checkbox-option {
+    display: flex;
+    align-items: center;
+    gap: 0.45rem;
+}
+
+.register__localities .register-list pb-custom-form.facets .checkbox-option {
+    color: var(--bb-dark-gray);
+    font-size: 0.95rem;
+}
+
+.register__localities .register-list pb-custom-form.facets .checkbox-input {
+    accent-color: var(--bb-beige);
+}
+
+.register__localities .register-list pb-custom-form.facets .checkboxes--subfilter {
+    margin-top: 0.4rem;
+    margin-left: 1.45rem;
+    padding-left: 0.75rem;
+    border-left: 2px solid var(--bb-light-gray);
+    display: flex;
+    flex-direction: column;
+    gap: 0.25rem;
+}
+
+.register__localities .register-list pb-custom-form.facets .checkboxes--subfilter.is-inactive {
+    opacity: 0.55;
 }
 
 .register__localities pb-leaflet-map {

--- a/resources/css/bullinger-theme.css
+++ b/resources/css/bullinger-theme.css
@@ -992,10 +992,38 @@ pb-view {
     grid-template-rows: auto auto minmax(0, 1fr);
     height: 100%;
     min-height: 0;
+    position: relative;
 }
 
 .register__localities .register-list pb-custom-form {
     min-height: 0;
+}
+
+.register__localities .register-scroll-top {
+    align-items: center;
+    background: transparent;
+    bottom: 0;
+    border: none;
+    color: var(--pb-link-color);
+    cursor: pointer;
+    display: inline-flex;
+    height: 2rem;
+    justify-content: center;
+    padding: 0;
+    position: absolute;
+    right: 0.2rem;
+    width: 2rem;
+    z-index: 20;
+}
+
+.register__localities .register-scroll-top:hover {
+    color: var(--bb-beige-dark);
+}
+
+.register__localities .register-scroll-top iron-icon {
+    --iron-icon-width: 24px;
+    --iron-icon-height: 24px;
+    --iron-icon-fill-color: currentColor;
 }
 
 .register__localities pb-split-list.register-split-list {
@@ -1011,7 +1039,7 @@ pb-view {
     display: block;
     min-height: 0;
     overflow-y: auto;
-    padding-bottom: 1rem;
+    padding-bottom: 3rem;
     box-sizing: border-box;
 }
 

--- a/resources/css/bullinger-theme.css
+++ b/resources/css/bullinger-theme.css
@@ -896,9 +896,19 @@ pb-view {
     margin: 0 0 0 -0.2rem;
 }
 
-.place-list .place-link {
+.place-list .place-item {
+    position: relative;
+    display: flex;
+    align-items: flex-start;
+}
+
+.place-list .place-main {
     display: inline-block;
     position: relative;
+}
+
+.place-list .place-link {
+    display: inline-block;
 }
 
 .place-list .place-name {
@@ -912,6 +922,8 @@ pb-view {
     color: var(--bb-dark-gray);
     display: none;
     font-size: 0.9rem;
+    left: 100%;
+    margin-left: 0.5rem;
     padding: 0.5rem 1rem;
     position: absolute;
     top: 0;
@@ -929,12 +941,22 @@ pb-view {
     font-weight: bold;
 }
 
-.place-list iron-icon.place-icon {
-    --iron-icon-fill-color: var(--bb-beige);
-    margin-right: 0.3rem;
+.place-list .place-geolocation {
+    display: inline-block;
+    flex-shrink: 0;
+    margin-right: 0.6rem;
 }
 
-.place-list .place-item:hover a.place-link {
+.place-list iron-icon.place-icon {
+    --iron-icon-fill-color: var(--bb-beige);
+}
+
+.place-list iron-icon.no-geolocation-icon {
+    --iron-icon-fill-color: var(--bb-link-disabled);
+    --iron-icon-height: 20px;
+}
+
+.place-list .place-item:hover .place-link {
     color: var(--bb-beige-dark);
 }
 
@@ -992,7 +1014,7 @@ pb-view {
 .register__localities pb-leaflet-map {
     grid-area: second;
     width: 100%;
-    height: 50vh;
+    height: 80vh;
 }
 
 @media (max-width: 768px) {

--- a/resources/css/bullinger-theme.css
+++ b/resources/css/bullinger-theme.css
@@ -1087,7 +1087,7 @@ pb-view {
     display: block;
     min-height: 0;
     overflow-y: auto;
-    padding-bottom: 5rem;
+    padding-bottom: 7rem;
     box-sizing: border-box;
 }
 

--- a/resources/css/bullinger-theme.css
+++ b/resources/css/bullinger-theme.css
@@ -979,24 +979,46 @@ pb-view {
     display: grid;
     grid-template-columns: 1fr 1fr;
     grid-gap: var(--s3);
-    margin-top: 3rem;
     grid-template-areas: "first second";
-}
-
-@media (max-width: 768px) {
-    .register__localities {
-        grid-gap: var(--s1);
-        grid-template-columns: 1fr;
-        grid-template-areas:
-        "second"
-        "first";
-        margin-top: 1rem;
-    }
+    height: 80vh;
+    margin-top: 3rem;
+    min-height: 0;
 }
 
 .register__localities .register-list {
     --pb-categorized-list-columns: 1;
+    display: grid;
     grid-area: first;
+    grid-template-rows: auto auto minmax(0, 1fr);
+    height: 100%;
+    min-height: 0;
+}
+
+.register__localities .register-list pb-custom-form {
+    min-height: 0;
+}
+
+.register__localities pb-split-list.register-split-list {
+    border-bottom: 1px solid var(--bb-dark-gray);
+    display: grid;
+    grid-template-rows: auto minmax(0, 1fr);
+    height: 100%;
+    min-height: 0;
+    overflow: hidden;
+}
+
+.register__localities pb-split-list.register-split-list::part(items) {
+    display: block;
+    min-height: 0;
+    overflow-y: auto;
+    padding-bottom: 1rem;
+    box-sizing: border-box;
+}
+
+.register__localities .place-list {
+    list-style: none;
+    padding: 0;
+    margin: 0 0 0 -0.2rem;
 }
 
 .register__localities .result-count {
@@ -1014,12 +1036,48 @@ pb-view {
 .register__localities pb-leaflet-map {
     grid-area: second;
     width: 100%;
-    height: 80vh;
+    height: 100%;
+    min-height: 0;
 }
 
 @media (max-width: 768px) {
+    .register__localities {
+        grid-gap: var(--s1);
+        grid-template-columns: 1fr;
+        grid-template-areas:
+            "second"
+            "first";
+        height: auto;
+        margin-top: 1rem;
+    }
+
+    .register__localities .register-list {
+        border-bottom: 1px solid var(--bb-dark-gray);
+        height: 52vh;
+        overflow: hidden;
+    }
+
+    .register__localities .register-list pb-custom-form {
+        max-width: 100%;
+    }
+
+    .register__localities .place-list {
+        height: auto;
+        overflow: visible;
+    }
+
     .register__localities pb-leaflet-map {
         height: 30vh;
+    }
+}
+
+@media (max-width: 768px) and (max-height: 768px) {
+    .register__localities pb-leaflet-map {
+        height: 22vh;
+    }
+    
+    .register__localities .register-list {
+        height: 57vh;
     }
 }
 

--- a/resources/i18n/app/de.json
+++ b/resources/i18n/app/de.json
@@ -172,7 +172,8 @@
         },
         "resultsCount": {
             "localities": "Gefundene Orte"
-        }
+        },
+        "scrollTop": "Zum Anfang der Ergebnisliste scrollen"
     },
     "sent": "Gesendet",
     "received": "Empfangen",

--- a/resources/i18n/app/de.json
+++ b/resources/i18n/app/de.json
@@ -138,6 +138,10 @@
         "correspondents": "Korrespondenten",
         "correspondentsAndMentioned": "Korrespondenten und erwähnte Personen",
         "correspondence": "Korrespondenz",
+        "correspondencePlaceOfDispatch": "Absendeort",
+        "correspondencePlaceOfReceipt": "Empfangsort",
+        "correspondencePlacesOfDispatch": "Absendeorte",
+        "correspondencePlacesOfReceipt": "Empfangsorte",
         "correspondenceAndMentions": "Korrespondenz und Erwähnungen",
         "all": "Alle",
         "archives": {

--- a/resources/i18n/app/de.json
+++ b/resources/i18n/app/de.json
@@ -173,7 +173,12 @@
         "resultsCount": {
             "localities": "Gefundene Orte"
         },
-        "scrollTop": "Zum Anfang der Ergebnisliste scrollen"
+        "scrollTop": "Zum Anfang der Ergebnisliste scrollen",
+        "localityType": {
+            "settlement": "Ort",
+            "district": "Bezirk/Region",
+            "country": "Land"
+        }
     },
     "sent": "Gesendet",
     "received": "Empfangen",

--- a/resources/i18n/app/de.json
+++ b/resources/i18n/app/de.json
@@ -143,6 +143,7 @@
         "correspondencePlacesOfDispatch": "Absendeorte",
         "correspondencePlacesOfReceipt": "Empfangsorte",
         "correspondenceAndMentions": "Korrespondenz und Erwähnungen",
+        "mentions": "Erwähnungen",
         "all": "Alle",
         "archives": {
             "name": "Archiv",

--- a/resources/i18n/app/en.json
+++ b/resources/i18n/app/en.json
@@ -143,6 +143,7 @@
         "correspondencePlacesOfDispatch": "Places of Dispatch",
         "correspondencePlacesOfReceipt": "Places of Receipt",
         "correspondenceAndMentions": "Correspondence and mentions",
+        "mentions": "Mentions",
         "all": "All",
         "archives": {
             "name": "Archive",

--- a/resources/i18n/app/en.json
+++ b/resources/i18n/app/en.json
@@ -138,6 +138,10 @@
         "correspondents": "Correspondents",
         "correspondentsAndMentioned": "Correspondents and mentioned persons",
         "correspondence": "Correspondence",
+        "correspondencePlaceOfDispatch": "Place of Dispatch",
+        "correspondencePlaceOfReceipt": "Place of Receipt",
+        "correspondencePlacesOfDispatch": "Places of Dispatch",
+        "correspondencePlacesOfReceipt": "Places of Receipt",
         "correspondenceAndMentions": "Correspondence and mentions",
         "all": "All",
         "archives": {

--- a/resources/i18n/app/en.json
+++ b/resources/i18n/app/en.json
@@ -173,7 +173,12 @@
         "resultsCount": {
             "localities": "Found Places"
         },
-        "scrollTop": "Scroll to top of results"
+        "scrollTop": "Scroll to top of results",
+        "localityType": {
+            "settlement": "Place",
+            "district": "District/Region",
+            "country": "Country"
+        }
     },
     "sent": "Sent",
     "received": "Received",

--- a/resources/i18n/app/en.json
+++ b/resources/i18n/app/en.json
@@ -172,7 +172,8 @@
         },
         "resultsCount": {
             "localities": "Found Places"
-        }
+        },
+        "scrollTop": "Scroll to top of results"
     },
     "sent": "Sent",
     "received": "Received",

--- a/resources/scripts/localities.js
+++ b/resources/scripts/localities.js
@@ -6,6 +6,9 @@ window.addEventListener('WebComponentsReady', function () {
   const viewCorrespondence = document.querySelector(
     'input[name="view"][value="correspondence"]',
   );
+  const viewMentions = document.querySelector(
+    'input[name="view"][value="mentions"]',
+  );
   const sentCheckbox = document.querySelector('input[name="correspSent"]');
   const receivedCheckbox = document.querySelector(
     'input[name="correspReceived"]',
@@ -19,6 +22,7 @@ window.addEventListener('WebComponentsReady', function () {
     !splitList ||
     !viewAll ||
     !viewCorrespondence ||
+    !viewMentions ||
     !sentCheckbox ||
     !receivedCheckbox ||
     !subfilter
@@ -43,7 +47,7 @@ window.addEventListener('WebComponentsReady', function () {
   }
 
   // "Correspondence and mentions":
-  // deactivate both subfilters and reload the list
+  // deactivate both correspondence subfilters and reload the list
   viewAll.addEventListener('change', function () {
     if (viewAll.checked) {
       setBothCorrespCheckboxes(false);
@@ -62,15 +66,27 @@ window.addEventListener('WebComponentsReady', function () {
     }
   });
 
+  // "Mentions":
+  // deactivate both correspondence subfilters and reload the list
+  viewMentions.addEventListener('change', function () {
+    if (viewMentions.checked) {
+      setBothCorrespCheckboxes(false);
+      updateSubfilterState();
+      submitFilter();
+    }
+  });
+
   // Switch to the correspondence view when selecting a correspondence role checkbox
   [sentCheckbox, receivedCheckbox].forEach(function (checkbox) {
     checkbox.addEventListener('change', function (ev) {
       viewAll.checked = false;
+      viewMentions.checked = false;
       viewCorrespondence.checked = true;
 
       // Keep at least one correspondence role filter selected
       if (!sentCheckbox.checked && !receivedCheckbox.checked) {
         ev.target.checked = true;
+        return;
       }
 
       updateSubfilterState();

--- a/resources/scripts/localities.js
+++ b/resources/scripts/localities.js
@@ -1,5 +1,6 @@
 window.addEventListener('WebComponentsReady', function () {
   // Main UI elements used for filtering, list updates and map interaction
+  const registerList = document.querySelector('.register-list');
   const splitList = document.querySelector('pb-split-list');
   const viewAll = document.querySelector('input[name="view"][value="all"]');
   const viewCorrespondence = document.querySelector(
@@ -14,6 +15,7 @@ window.addEventListener('WebComponentsReady', function () {
 
   // Abort if required elements for filtering are not available
   if (
+    !registerList ||
     !splitList ||
     !viewAll ||
     !viewCorrespondence ||
@@ -92,8 +94,15 @@ window.addEventListener('WebComponentsReady', function () {
     scrollTopButton.addEventListener('click', scrollItemsToTop);
   }
 
+  // Show a loading overlay while the locality list is being updated
+  pbEvents.subscribe('pb-start-update', 'transcription', function () {
+    registerList.classList.add('is-loading');
+  });
+
   // Synchronize markers on the map after the update finished
   pbEvents.subscribe('pb-end-update', 'transcription', function () {
+    // Hide the loading overlay and reset scroll position
+    registerList.classList.remove('is-loading');
     scrollItemsToTop();
 
     pbEvents.emit('pb-update', 'map', {

--- a/resources/scripts/localities.js
+++ b/resources/scripts/localities.js
@@ -1,0 +1,115 @@
+window.addEventListener('WebComponentsReady', function () {
+  // Main UI elements used for filtering, list updates and map interaction
+  const splitList = document.querySelector('pb-split-list');
+  const viewAll = document.querySelector('input[name="view"][value="all"]');
+  const viewCorrespondence = document.querySelector(
+    'input[name="view"][value="correspondence"]',
+  );
+  const sentCheckbox = document.querySelector('input[name="correspSent"]');
+  const receivedCheckbox = document.querySelector(
+    'input[name="correspReceived"]',
+  );
+  const subfilter = document.querySelector('.checkboxes--subfilter');
+  const scrollTopButton = document.getElementById('register-scroll-top');
+
+  // Abort if required elements for filtering are not available
+  if (
+    !splitList ||
+    !viewAll ||
+    !viewCorrespondence ||
+    !sentCheckbox ||
+    !receivedCheckbox ||
+    !subfilter
+  ) {
+    return;
+  }
+
+  // Trigger a refresh of the locality list
+  function submitFilter() {
+    splitList.submit();
+  }
+
+  // Convenience helper to toggle both correspondence role filters
+  function setBothCorrespCheckboxes(checked) {
+    sentCheckbox.checked = checked;
+    receivedCheckbox.checked = checked;
+  }
+
+  // Visually indicate whether the correspondence subfilter is active
+  function updateSubfilterState() {
+    subfilter.classList.toggle('is-inactive', !viewCorrespondence.checked);
+  }
+
+  // "Correspondence and mentions":
+  // deactivate both subfilters and reload the list
+  viewAll.addEventListener('change', function () {
+    if (viewAll.checked) {
+      setBothCorrespCheckboxes(false);
+      updateSubfilterState();
+      submitFilter();
+    }
+  });
+
+  // "Correspondence":
+  // activate both correspondence role filters by default
+  viewCorrespondence.addEventListener('change', function () {
+    if (viewCorrespondence.checked) {
+      setBothCorrespCheckboxes(true);
+      updateSubfilterState();
+      submitFilter();
+    }
+  });
+
+  // Switch to the correspondence view when selecting a correspondence role checkbox
+  [sentCheckbox, receivedCheckbox].forEach(function (checkbox) {
+    checkbox.addEventListener('change', function (ev) {
+      viewAll.checked = false;
+      viewCorrespondence.checked = true;
+
+      // Keep at least one correspondence role filter selected
+      if (!sentCheckbox.checked && !receivedCheckbox.checked) {
+        ev.target.checked = true;
+      }
+
+      updateSubfilterState();
+      submitFilter();
+    });
+  });
+
+  updateSubfilterState();
+
+  // Scroll the result list back to the first item
+  function scrollItemsToTop() {
+    const items = splitList.shadowRoot?.querySelector('#items');
+
+    if (items) {
+      items.scrollTop = 0;
+    }
+  }
+
+  // Shortcut button for scrolling back to the top of the list
+  if (scrollTopButton) {
+    scrollTopButton.addEventListener('click', scrollItemsToTop);
+  }
+
+  // Synchronize markers on the map after the update finished
+  pbEvents.subscribe('pb-end-update', 'transcription', function () {
+    scrollItemsToTop();
+
+    pbEvents.emit('pb-update', 'map', {
+      root: splitList,
+    });
+  });
+
+  // Navigate to the locality detail page when a map marker is clicked
+  pbEvents.subscribe('pb-leaflet-marker-click', 'map', function (ev) {
+    const geo = ev.detail.element;
+    const item = geo.closest('.js-place-item');
+    const link = item ? item.querySelector('.js-place-link') : null;
+    const href = link ? link.getAttribute('href') : null;
+
+    if (href) {
+      window.location = href;
+    }
+  });
+});

--- a/templates/localities.html
+++ b/templates/localities.html
@@ -2,7 +2,7 @@
     <head data-template="lib:include" data-template-path="templates/header.html">
         <title data-target="title-template" data-template-page="localities">Bullinger Digital: Orte</title>
         <meta data-target="title-template" name="pb-template" content="localities.html"/>
-        <script data-target="script-preload" type="module" src="pb-leaflet-map.js" data-template="pages:load-components"></script>
+        <script data-target="script-preload" type="module" src="pb-leaflet-map.js" data-template="pages:load-components"/>
     </head>
 
     <body>
@@ -37,7 +37,7 @@
                         subscribe="transcription" 
                         data-template="pages:parse-params"/>
                 </div>
-                <pb-leaflet-map id="map" subscribe="map" emit="map" zoom="3" cluster="" latitude="50" longitude="20">
+                <pb-leaflet-map id="map" subscribe="map" emit="map" zoom="9" fit-markers="" cluster="" latitude="50" longitude="20">
                     <pb-map-layer show=""
                         base="" 
                         label="Mapbox OSM"
@@ -47,7 +47,6 @@
                         attribution="© Mapbox © OpenStreetMap">
                     </pb-map-layer>
                 </pb-leaflet-map>
-
 
                 <!-- pb-leaflet-map id="map" subscribe="map" emit="map" zoom="10" cluster=""
                     latitude="47.69732" longitude="8.63493">
@@ -64,27 +63,23 @@
         <footer data-template="templates:include" data-template-path="templates/footer.html"/>
         <script>
             window.addEventListener('WebComponentsReady', function() {
-                const map = document.querySelector('pb-leaflet-map');
-
-                pbEvents.subscribe('pb-page-ready', null, function() {
-                    const pbPage = document.querySelector('pb-page');
-                    const endpoint = pbPage.getEndpoint();
-                    const url = endpoint + '/api/localities-all';
-
-                    fetch(url)
-                        .then(function(response) {
-                            return response.json();
-                        })
-                        .then(function(json) {
-                            pbEvents.emit('pb-update-map', 'map', json);
-                        });
+                const splitList = document.querySelector('pb-split-list');
+            
+                pbEvents.subscribe('pb-end-update', 'transcription', function() {
+                    pbEvents.emit('pb-update', 'map', {
+                        root: splitList
+                    });
                 });
-
+            
                 pbEvents.subscribe('pb-leaflet-marker-click', 'map', function(ev) {
-                    const label = ev.detail.element.label;
-                    const key = ev.detail.element.id;
-                    const category = label.substring(0, 1);
-                    window.location = key + '?category=' + category;
+                    const geo = ev.detail.element;
+                    const item = geo.closest('.js-place-item');
+                    const link = item ? item.querySelector('.js-place-link') : null;
+                    const href = link ? link.getAttribute('href') : null;
+                
+                    if (href) {
+                        window.location = href;
+                    }
                 });
             });
         </script>

--- a/templates/localities.html
+++ b/templates/localities.html
@@ -36,6 +36,10 @@
                         emit="transcription" 
                         subscribe="transcription" 
                         data-template="pages:parse-params"/>
+                    <button id="register-scroll-top" class="register-scroll-top" type="button"
+                        data-i18n="[title]registers.scrollTop;[aria-label]registers.scrollTop">
+                        <iron-icon icon="icons:expand-less"></iron-icon>
+                    </button>
                 </div>
                 <pb-leaflet-map id="map" subscribe="map" emit="map" zoom="9" fit-markers="" cluster="" latitude="50" longitude="20">
                     <pb-map-layer show=""
@@ -64,6 +68,7 @@
         <script>
             window.addEventListener('WebComponentsReady', function() {
                 const splitList = document.querySelector('pb-split-list');
+                const scrollTopButton = document.getElementById('register-scroll-top');
 
                 function scrollItemsToTop() {
                     const items = splitList.shadowRoot?.querySelector('#items');
@@ -71,6 +76,10 @@
                     if (items) {
                         items.scrollTop = 0;
                     }
+                }
+
+                if (scrollTopButton) {
+                    scrollTopButton.addEventListener('click', scrollItemsToTop);
                 }
             
                 pbEvents.subscribe('pb-end-update', 'transcription', function() {

--- a/templates/localities.html
+++ b/templates/localities.html
@@ -53,6 +53,16 @@
                                     </label>
                                 </div>
                             </div>
+                            <div class="radio-option-group">
+                                <label class="radio-option">
+                                    <input class="radio-input"
+                                        type="radio"
+                                        name="view"
+                                        value="mentions"
+                                        data-template="templates:form-control" />
+                                    <pb-i18n key="registers.mentions">Erwähnungen</pb-i18n>
+                                </label>
+                            </div>
                         </div>
                     </pb-custom-form>
                     <pb-custom-form id="options" auto-submit="paper-input,paper-icon-button" emit="transcription">

--- a/templates/localities.html
+++ b/templates/localities.html
@@ -12,16 +12,47 @@
             </header>
             <main class="register register__localities center-l">
                 <div class="register-list">
-                    <pb-custom-form id="filter" class="facets" auto-submit="[name=view]" emit="transcription">
-                        <div class="radios">
-                            <label class="radio-option">
-                                <input class="radio-input" type="radio" name="view" checked="checked" value="all" data-template="templates:form-control" />
-                                <pb-i18n key="registers.correspondenceAndMentions">Korrespondenz und Erwähnungen</pb-i18n>
-                            </label>
-                            <label class="radio-option">
-                                <input class="radio-input" type="radio" name="view" value="correspondence" data-template="templates:form-control" />
-                                <pb-i18n key="registers.correspondence">Korrespondenz</pb-i18n>
-                            </label>
+                    <pb-custom-form id="filter" class="facets" emit="transcription">
+                        <div class="radios radios--main">
+                            <div class="radio-option-group">
+                                <label class="radio-option">
+                                    <input class="radio-input"
+                                        type="radio"
+                                        name="view"
+                                        checked="checked"
+                                        value="all"
+                                        data-template="templates:form-control" />
+                                    <pb-i18n key="registers.correspondenceAndMentions">Korrespondenz und Erwähnungen</pb-i18n>
+                                </label>
+                            </div>
+                            <div class="radio-option-group radio-option-group--correspondence">
+                                <label class="radio-option">
+                                    <input class="radio-input"
+                                        type="radio"
+                                        name="view"
+                                        value="correspondence"
+                                        data-template="templates:form-control" />
+                                    <pb-i18n key="registers.correspondence">Korrespondenz</pb-i18n>
+                                </label>
+                                <div class="checkboxes checkboxes--subfilter">
+                                    <label class="checkbox-option">
+                                        <input class="checkbox-input"
+                                            type="checkbox"
+                                            name="correspSent"
+                                            value="1"
+                                            data-template="templates:form-control" />
+                                        <pb-i18n key="registers.correspondencePlacesOfDispatch">Absendeorte</pb-i18n>
+                                    </label>
+                                    <label class="checkbox-option">
+                                        <input class="checkbox-input"
+                                            type="checkbox"
+                                            name="correspReceived"
+                                            value="1"
+                                            data-template="templates:form-control" />
+                                        <pb-i18n key="registers.correspondencePlacesOfReceipt">Empfangsorte</pb-i18n>
+                                    </label>
+                                </div>
+                            </div>
                         </div>
                     </pb-custom-form>
                     <pb-custom-form id="options" auto-submit="paper-input,paper-icon-button" emit="transcription">
@@ -65,43 +96,7 @@
             </main>
         </pb-page>
         <footer data-template="templates:include" data-template-path="templates/footer.html"/>
-        <script>
-            window.addEventListener('WebComponentsReady', function() {
-                const splitList = document.querySelector('pb-split-list');
-                const scrollTopButton = document.getElementById('register-scroll-top');
-
-                function scrollItemsToTop() {
-                    const items = splitList.shadowRoot?.querySelector('#items');
-            
-                    if (items) {
-                        items.scrollTop = 0;
-                    }
-                }
-
-                if (scrollTopButton) {
-                    scrollTopButton.addEventListener('click', scrollItemsToTop);
-                }
-            
-                pbEvents.subscribe('pb-end-update', 'transcription', function() {
-                    scrollItemsToTop();
-
-                    pbEvents.emit('pb-update', 'map', {
-                        root: splitList
-                    });
-                });
-            
-                pbEvents.subscribe('pb-leaflet-marker-click', 'map', function(ev) {
-                    const geo = ev.detail.element;
-                    const item = geo.closest('.js-place-item');
-                    const link = item ? item.querySelector('.js-place-link') : null;
-                    const href = link ? link.getAttribute('href') : null;
-                
-                    if (href) {
-                        window.location = href;
-                    }
-                });
-            });
-        </script>
+        <script src="resources/scripts/localities.js"></script>
     </body>
 
 </html>

--- a/templates/localities.html
+++ b/templates/localities.html
@@ -60,13 +60,18 @@
                             <paper-icon-button icon="search" slot="suffix"/>
                         </paper-input>
                     </pb-custom-form>
-                    <pb-split-list class="register-split-list" 
-                        url="api/localities-all-list" 
-                        subforms="#options,#filter" 
-                        selected="A" 
-                        emit="transcription" 
-                        subscribe="transcription" 
-                        data-template="pages:parse-params"/>
+                    <div class="register-results">
+                        <pb-split-list class="register-split-list" 
+                            url="api/localities-all-list" 
+                            subforms="#options,#filter" 
+                            selected="A" 
+                            emit="transcription" 
+                            subscribe="transcription" 
+                            data-template="pages:parse-params"/>
+                        <div class="register-loading" aria-hidden="true">
+                            <iron-icon icon="icons:refresh"></iron-icon>
+                        </div>
+                    </div>
                     <button id="register-scroll-top" class="register-scroll-top" type="button"
                         data-i18n="[title]registers.scrollTop;[aria-label]registers.scrollTop">
                         <iron-icon icon="icons:expand-less"></iron-icon>

--- a/templates/localities.html
+++ b/templates/localities.html
@@ -64,8 +64,18 @@
         <script>
             window.addEventListener('WebComponentsReady', function() {
                 const splitList = document.querySelector('pb-split-list');
+
+                function scrollItemsToTop() {
+                    const items = splitList.shadowRoot?.querySelector('#items');
+            
+                    if (items) {
+                        items.scrollTop = 0;
+                    }
+                }
             
                 pbEvents.subscribe('pb-end-update', 'transcription', function() {
+                    scrollItemsToTop();
+
                     pbEvents.emit('pb-update', 'map', {
                         root: splitList
                     });

--- a/templates/pages/locality.html
+++ b/templates/pages/locality.html
@@ -37,10 +37,29 @@
                     <pb-custom-form class="facets" auto-submit="[name=view]" event="pb-results-received" subscribe="grid" emit="grid">
                         <div class="radios">
                             <label class="radio-option">
-                                <input class="radio-input" type="radio" name="view" checked="checked" value="all" data-template="templates:form-control"/> <pb-i18n key="registers.correspondenceAndMentions">(Korrespondenz und Erwähnungen)</pb-i18n>
+                                <input class="radio-input" 
+                                    type="radio" 
+                                    name="view" 
+                                    checked="checked" 
+                                    value="all" 
+                                    data-template="templates:form-control"/> 
+                                <pb-i18n key="registers.correspondenceAndMentions">Korrespondenz und Erwähnungen</pb-i18n>
                             </label>
                             <label class="radio-option">
-                                <input class="radio-input" type="radio" name="view" value="correspondence" data-template="templates:form-control"/> <pb-i18n key="registers.correspondence">(Korrespondenz)</pb-i18n>
+                                <input class="radio-input" 
+                                    type="radio" 
+                                    name="view" 
+                                    value="correspondence" 
+                                    data-template="templates:form-control"/> 
+                                <pb-i18n key="registers.correspondence">Korrespondenz</pb-i18n>
+                            </label>
+                            <label class="radio-option">
+                                <input class="radio-input"
+                                    type="radio"
+                                    name="view"
+                                    value="mentions"
+                                    data-template="templates:form-control"/>
+                                <pb-i18n key="registers.mentions">Erwähnungen</pb-i18n>
                             </label>
                         </div>
                     </pb-custom-form>


### PR DESCRIPTION
### Summary

This PR extends the localities register and locality detail pages by improving map integration, navigation, filtering, and locality statistics display.

It depends on the corresponding bullinger-korpus-tei PR: https://github.com/stazh/bullinger-korpus-tei/pull/5
The generated localities-statistics.xml file introduced in that PR is used to provide correspondence and mention counts for localities and to support the new filtering options in the register.

### Changes

**Map integration**

- Refactored locality map integration to use pb-update events
- Replaced the previous API-based marker loading with list-based map markers
- Removed the dedicated localities-all endpoint

**Localities register usability**

- Improved register layout and scrolling behavior
- Added a scroll-to-top control for easier navigation through large result sets
- Added loading indicators while register results are updated

**Locality display improvements**

- Improved locality ordering
- Added optional contextual labels for locality types to distinguish places, districts/regions, and countries when necessary
- Introduced a feature flag controlling whether locality type labels are displayed

**Correspondence statistics and filtering**

- Added subfilters for places of dispatch and places of receipt within the correspondence view
- Added correspondence counts to locality tooltips

**Mentions statistics and filtering**

- Added a dedicated mentions filter to the localities register and the locality detail page
- Added mention counts to locality tooltips


<img width="1249" height="863" alt="image" src="https://github.com/user-attachments/assets/0f1f594a-87af-44d8-abb3-641746a49ef2" />

