### PR TITLE
Support for alignments in edited and provisional letters

### DIFF
--- a/.devcontainer/Dockerfile.dev
+++ b/.devcontainer/Dockerfile.dev
@@ -16,6 +16,9 @@ RUN su vscode -c "source /usr/local/sdkman/bin/sdkman-init.sh && sdk install ant
 ENV ANT_HOME=/usr/local/sdkman/candidates/ant/current
 ENV PATH=${PATH}:${ANT_HOME}/bin
 
+RUN curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg \
+    | gpg --dearmor | sudo tee /usr/share/keyrings/yarn-archive-keyring.gpg >/dev/null
+
 # Install python pip and upgrade it to latest version
 RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
     && apt-get -y install --no-install-recommends bzip2 \

--- a/.devcontainer/devcontainer-lock.json
+++ b/.devcontainer/devcontainer-lock.json
@@ -1,0 +1,9 @@
+{
+  "features": {
+    "ghcr.io/devcontainers/features/node:1": {
+      "version": "1.7.1",
+      "resolved": "ghcr.io/devcontainers/features/node@sha256:8c0de46939b61958041700ee89e3493f3b2e4131a06dc46b4d9423427d06e5f6",
+      "integrity": "sha256:8c0de46939b61958041700ee89e3493f3b2e4131a06dc46b4d9423427d06e5f6"
+    }
+  }
+}

--- a/resources/odd/bullinger.odd
+++ b/resources/odd/bullinger.odd
@@ -363,11 +363,20 @@
                     <model behaviour="paragraph"></model>
                 </elementSpec>
                 <elementSpec ident="lb" mode="change">
-                    <model behaviour="inline" predicate="let $id := @xml:id || '-0'   return exists(id($id, .))">
+                    <!-- Output <br> before <pb-facs-link> when lb is explicitly manual (@type='manual')
+                         or when the letter was transcribed by HTR (TEI/@source='HTR'), where every lb is a real line break -->
+                    <model behaviour="inline" predicate="(@type='manual' or ancestor::*:TEI/@source='HTR') and (let $id := @xml:id || '-0'   return exists(id($id, .)))">
                         <param name="order" value="tokenize(@xml:id, '\D+')[. ne ''][1]" />
                         <param name="coordinates" value="let $id := @xml:id || '-0'   return ext:convert-polygon-to-coordinates(id($id, .)/@points)" />
                         <pb:template xmlns="" xml:space="preserve">
                             <br />
+                            <pb-facs-link class="facs-link-hidden" emit="facsimile" order="[[order]]" subscribe="facsimile" coordinates="[[coordinates]]"></pb-facs-link>
+                        </pb:template>
+                    </model>
+                    <model behaviour="inline" predicate="let $id := @xml:id || '-0'   return exists(id($id, .))">
+                        <param name="order" value="tokenize(@xml:id, '\D+')[. ne ''][1]" />
+                        <param name="coordinates" value="let $id := @xml:id || '-0'   return ext:convert-polygon-to-coordinates(id($id, .)/@points)" />
+                        <pb:template xmlns="" xml:space="preserve">
                             <pb-facs-link class="facs-link-hidden" emit="facsimile" order="[[order]]" subscribe="facsimile" coordinates="[[coordinates]]"></pb-facs-link>
                         </pb:template>
                     </model>

--- a/resources/scripts/app.js
+++ b/resources/scripts/app.js
@@ -128,50 +128,5 @@ window.addEventListener('DOMContentLoaded', function() {
          });
     });
 
-    pbEvents.subscribe('pb-update', 'transcription', ev => {
-        const view = document.getElementById('view1');
-
-        // Collect the y positions of all pb-facs-link elements in the transcription
-        let yPositions = [];
-
-        const updatePositions = () => {
-            yPositions = [];
-            const teiLineBreaks = view.shadowRoot.querySelectorAll("pb-facs-link.facs-link-hidden");
-            teiLineBreaks.forEach((teiLb) => {
-                const y = teiLb.getBoundingClientRect().top + window.scrollY;
-                yPositions.push({
-                    y: y,
-                    order: teiLb.getAttribute('order'),
-                    coordinates: teiLb.getAttribute('coordinates')
-                });
-            });
-        };
-
-        updatePositions();
-
-        // Update the y positions when the size of view1 changes
-        const observer = new ResizeObserver(updatePositions);
-        observer.observe(view);
-
-        // When the mouse is moved over the transcription, trigger the pb-show-annotation event
-        // of the closest pb-facs-link element based on the y position of the mouse
-        view.shadowRoot.addEventListener('mousemove', (ev) => {
-            if(!yPositions.length) return;
-            const y = ev.clientY + window.scrollY;
-            // Find the nearest element: the one with the highest y position that is still smaller than the mouse y position
-            const closest = yPositions.reduce((prev, curr) => {
-                if (curr.y <= y && (!prev || curr.y > prev.y)) {
-                    return curr;
-                }
-                return prev;
-            }, null);
-            if (closest) {
-                pbEvents.emit('pb-show-annotation', 'facsimile', { order: closest.order, coordinates: JSON.parse(closest.coordinates) });
-            } else {
-                pbEvents.emit('pb-show-annotation', 'facsimile', { coordinates: null });
-            }
-        });
-    });
-
     observeBodyClassChangeWithRetry();
 });

--- a/resources/scripts/facs-highlight.js
+++ b/resources/scripts/facs-highlight.js
@@ -1,0 +1,114 @@
+window.addEventListener('DOMContentLoaded', function () {
+    function clearHighlight() {
+        const facsimile = document.getElementById('facsimile');
+        if (facsimile && facsimile.overlay && facsimile._tify?.viewer) {
+            facsimile._tify.viewer.removeOverlay(facsimile.overlay);
+            facsimile.overlay = null;
+        }
+        CSS.highlights?.delete('facs-text-highlight');
+    }
+
+    function highlightTextRange(targetPos, positions, contentDiv) {
+        if (!CSS.highlights) return;
+        CSS.highlights.delete('facs-text-highlight');
+        if (!targetPos) return;
+
+        const idx = positions.indexOf(targetPos);
+        if (idx < 0) return;
+
+        const range = new Range();
+        range.setStartAfter(targetPos.element);
+        if (idx + 1 < positions.length) {
+            range.setEndBefore(positions[idx + 1].element);
+        } else {
+            range.setEnd(contentDiv, contentDiv.childNodes.length);
+        }
+
+        CSS.highlights.set('facs-text-highlight', new Highlight(range));
+    }
+
+    // Returns the text node at (x, y) inside shadowRoot, falling back to the element.
+    // A text node sits precisely between its sibling facs-links, so compareDocumentPosition
+    // works correctly even when multiple facs-links share the same parent element.
+    function findNodeAtPoint(x, y, shadowRoot) {
+        const element = shadowRoot.elementFromPoint(x, y);
+        if (!element) return null;
+        const walker = document.createTreeWalker(element, NodeFilter.SHOW_TEXT);
+        let node;
+        while ((node = walker.nextNode())) {
+            const range = document.createRange();
+            range.selectNodeContents(node);
+            for (const rect of range.getClientRects()) {
+                if (x >= rect.left && x <= rect.right && y >= rect.top && y <= rect.bottom) {
+                    return node;
+                }
+            }
+        }
+        return element;
+    }
+
+    pbEvents.subscribe('pb-update', 'transcription', ev => {
+        const view = document.getElementById('view1');
+
+        const style = document.createElement('style');
+        style.textContent = '::highlight(facs-text-highlight) { background-color: rgba(0, 0, 128, 0.08); }';
+        view.shadowRoot.appendChild(style);
+
+        let positions = [];
+        let contentDiv = null;
+
+        const updatePositions = () => {
+            positions = [];
+            contentDiv = view.shadowRoot.querySelector('#content');
+            view.shadowRoot.querySelectorAll('pb-facs-link.facs-link-hidden').forEach(el => {
+                positions.push({
+                    element: el,
+                    order: el.getAttribute('order'),
+                    coordinates: el.getAttribute('coordinates')
+                });
+            });
+        };
+
+        updatePositions();
+
+        // Re-collect if the transcription content is re-rendered
+        const observer = new ResizeObserver(updatePositions);
+        observer.observe(view);
+
+        view.addEventListener('mouseleave', clearHighlight);
+
+        view.shadowRoot.addEventListener('mousemove', (ev) => {
+            if (!positions.length) return;
+
+            // Resolve the precise node under the cursor. elementFromPoint returns an element,
+            // but when two facs-links share the same parent element, comparing the parent via
+            // compareDocumentPosition gives CONTAINS|PRECEDING — not FOLLOWING — and we break
+            // too early. A text node between siblings is exact, so we look for one first.
+            const target = findNodeAtPoint(ev.clientX, ev.clientY, view.shadowRoot);
+            if (!target || target.nodeType !== Node.TEXT_NODE || !contentDiv?.contains(target)
+                    || target.parentElement?.closest('.inline-remark')) {
+                clearHighlight();
+                return;
+            }
+
+            // Walk positions in DOM order; keep the last facs-link that precedes the target.
+            // DOCUMENT_POSITION_FOLLOWING means target comes after pos.element in the DOM tree.
+            let closest = null;
+            for (const pos of positions) {
+                if (pos.element.compareDocumentPosition(target) & Node.DOCUMENT_POSITION_FOLLOWING) {
+                    closest = pos;
+                } else {
+                    break;
+                }
+            }
+
+            if (!closest) {
+                clearHighlight();
+                return;
+            }
+
+            pbEvents.emit('pb-show-annotation', 'facsimile', { order: closest.order, coordinates: JSON.parse(closest.coordinates) });
+            highlightTextRange(closest, positions, contentDiv);
+        });
+    });
+});

--- a/static/about-de.html
+++ b/static/about-de.html
@@ -67,11 +67,31 @@
                 <p>Die Quelle bzw. Art der Transkription ist im <iron-icon style="margin-top:-4px;" slot="default"
                         icon="info-outline" class="source-info--icon"></iron-icon> neben der
                     Überschrift «Brieftext» ausgewiesen.</p>
-                <p>Aus dieser Aufstellung ergibt sich, dass keine Transkriptionen
-                    vorliegen für Briefe, für die keine Faksimiles beschafft werden
-                    konnten.</p>
             </blockquote>
             <ul>
+                <li>
+                    <p>Alignierungen zwischen Faksimile (Bild) und Transkription
+                        (Text).</p>
+                    <ul>
+                        <li>
+                            <p>Alle Alignierungen sind automatisch erstellt, was insbesondere bei
+                                anspruchsvollem Layout oder Worttrennungen am Zeilenende zu Fehlern
+                                führen kann.</p>
+                        </li>
+                        <li>
+                            <p>Manuelle Transkriptionen orientieren sich nicht am Layout der
+                                Faksimiles, d.h. Zeilenumbrüche und Abschnittswechsel stimmen nicht
+                                überein. Für die Alignierung ist die Zeile im Faksimile massgebend,
+                                in der Transkription kann sich der zugehörige Text auf 2 Zeilen
+                                verteilen.</p>
+                        </li>
+                        <li>
+                            <p>Die automatisch erstellten Transkriptionen folgen dem Layout im
+                                Manuskript, d.h. eine Zeile im Faksimile entspricht einer Zeile in
+                                der Transkription.</p>
+                        </li>
+                    </ul>
+                </li>
                 <li>
                     <p>Editionskritische Anmerkungen und Sachkommentare</p>
                     <ul>
@@ -125,7 +145,9 @@
                         </li>
                         <li>
                             <p>Orte, die in den Briefen erwähnt werden oder als Absende- oder
-                                Empfangsort ausgewiesen sind</p>
+                                Empfangsort ausgewiesen sind. Die ausgewiesenen Orte werden auf der
+                                interaktiven Landkarte angezeigt. Über die Karte lässt sich direkt
+                                zu den Briefen navigieren.</p>
                         </li>
                         <li>
                             <p>Institutionen / Gruppen, die als Korrespondenzpartner
@@ -324,9 +346,11 @@
                 </li>
                 <li>
                     <p>Namensanzeige<br />
-                        Sie können sich die in einem Brief (Regest, Brieftext, Fussnoten)
-                        erwähnten Personen- und Ortsnamen anzeigen lassen, indem Sie oberhalb
-                        der Metadaten die Box «Namen markieren» anklicken. Wenn Sie mit der Maus
+                        Sie können sich die in Regest, Brieftext und Fussnoten erwähnten
+                        Personen- und Ortsnamen anzeigen lassen, indem Sie oberhalb der
+                        Metadaten die Box «Namen markieren» anklicken. Dieselbe Funktion steht
+                        auch oberhalb des Brieftextes (Box «Namen markieren») zur Verfügung.
+                        Wenn Sie mit der Maus
                         über die Markierung fahren, werden die im Register eingetragenen Namen
                         angezeigt. Wenn Sie auf diese Namen klicken, gelangen Sie zur
                         entsprechenden Detailseite (s. Register). Nur für Briefe mit manueller

--- a/static/about-en.html
+++ b/static/about-en.html
@@ -61,9 +61,30 @@
                 <p>The source and type of transcription is indicated in the <iron-icon style="margin-top:-4px;"
                         slot="default" icon="info-outline" class="source-info--icon"></iron-icon> next to the heading
                     “Letter Text.”</p>
-                <p>No transcriptions are available for letters for which we have no facsimiles.</p>
             </blockquote>
             <ul>
+                <li>
+                    <p>Alignments between facsimile (image) and transcription (text).</p>
+                    <ul>
+                        <li>
+                            <p>All alignments are generated automatically, which can lead to errors,
+                                especially with complex layouts or words hyphenated at the end of a
+                                line.</p>
+                        </li>
+                        <li>
+                            <p>Manual transcriptions do not follow the layout of the facsimiles,
+                                i.e. line breaks and paragraph breaks do not correspond. The line in
+                                the facsimile is authoritative for the alignment; in the
+                                transcription the corresponding text may be spread over two
+                                lines.</p>
+                        </li>
+                        <li>
+                            <p>Machine-generated transcriptions follow the layout of the manuscript,
+                                i.e. one line in the facsimile corresponds to one line in the
+                                transcription.</p>
+                        </li>
+                    </ul>
+                </li>
                 <li>
                     <p>Editorial notes and comments</p>
                     <ul>
@@ -109,7 +130,9 @@
                             </ul>
                         </li>
                         <li>
-                            <p>Places mentioned or designated as locations of sending or receiving a letter</p>
+                            <p>Places mentioned or designated as locations of sending or receiving a
+                                letter. The places listed are shown on the interactive map. The map
+                                allows you to navigate directly to the letters.</p>
                         </li>
                         <li>
                             <p>Institutions/groups acting as correspondents</p>
@@ -286,8 +309,9 @@
                 </li>
                 <li>
                     <p>Name display<br />
-                        You can highlight person and place names mentioned in a letter (in the summary, text, and
-                        footnotes) by clicking “Highlight names” above the metadata. Clicking on an underlined name
+                        You can highlight person and place names mentioned in the summary, letter text, and
+                        footnotes by clicking “Highlight names” above the metadata. The same function is also
+                        available above the letter text (“Highlight names” box). Clicking on an underlined name
                         shows the indexed name. Clicking on the indexed name opens its detail page (see Index). This
                         option is only available for manually transcribed letters.</p>
                 </li>

--- a/templates/pages/letter.html
+++ b/templates/pages/letter.html
@@ -68,5 +68,6 @@
         <footer data-template="lib:include" data-template-path="templates/footer.html"></footer>
     </pb-page>
     <script src="resources/scripts/app.js"></script>
+    <script src="resources/scripts/facs-highlight.js"></script>
 </body>
 </html>


### PR DESCRIPTION
Extends facsimile line alignment beyond HTR transcriptions to edited and provisional letters, where line breaks in the TEI don't correspond to actual lines on the page.

This PR is a requirement for https://github.com/stazh/bullinger-korpus-tei/pull/6.

**Changes**

- **ODD (`bullinger.odd`)**: Split the `lb` model in two. A `<br>` is only emitted when the line break is real — either `@type='manual'` or the whole letter text comes from HTR (`TEI/@source='HTR'`). All other `lb` elements still emit the hidden `pb-facs-link` for alignment, but without forcing a visual line break.
- **New `resources/scripts/facs-highlight.js`**: Replaces the y-position-based hover logic that lived in `app.js`. Instead of comparing mouse coordinates against cached bounding boxes, it resolves the text node under the cursor (`elementFromPoint` + a text-node walk) and finds the last preceding `pb-facs-link` in DOM order. This works when several line breaks share one rendered line, which is a usual case in the edited letters.
- **Adds a CSS Custom Highlight** `::highlight(facs-text-highlight)` so the text segment corresponding to the highlighted facsimile region is shaded, and clears both highlight and facsimile overlay on mouseleave or when the cursor isn't over transcription text (e.g. inline remarks).
- **`app.js`**: Removed the old `pb-update` hover handler.
- **`letter.html`**: Loads the new script.
- **`static/about-*.html`**: Updated about pages.